### PR TITLE
ci workflow fixes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: NPM Rebuild
-        run: npm run ci
+        run: npm ci
       - name: NPM Lint
         run: npm run lint
       - name: NPM Test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: NPM Rebuild
-        run: npm run rebuild
+        run: npm run ci
       - name: NPM Lint
         run: npm run lint
       - name: NPM Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           result-encoding: string
           script: |
             const { repo: { owner, repo }, sha } = context;
-            const tag = process.env.DATE;
+            const tag = process.env.PACKAGE;
             let release_id = 0;
 
             try {
@@ -96,8 +96,8 @@ jobs:
   npm:
     runs-on: ubuntu-latest
     if: ${{ contains(github.ref, 'main') }}
-    name: GitHub Release
-    needs: [tagging]
+    name: NPM Release
+    needs: [tagging, release]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
- Updated pr test to run npm ci and use pinned packages in package-lock
- Fixed release workflow bug, it will now use PACKAGE variable
