### PR TITLE
feat: add ability to shutdonw tracing gracefully

### DIFF
--- a/deployment/base/job.yml
+++ b/deployment/base/job.yml
@@ -34,4 +34,4 @@ spec:
       gitRepo:
         directory: "."
         repository: "https://github.com/saidsef/tracing-node.git"
-        revision: "version-bump"
+        revision: "tracing-shutdown"


### PR DESCRIPTION
1. **Logger Configuration**:
- ~The `diag.setLogger` function now uses a `DiagConsoleLogger` with a log level set to `INFO`. This ensures that tracing logs are properly configured for debugging purposes.~

2. **Tracer Provider Initialization**:
- The `NodeTracerProvider` is now initialized with a `Resource` object that includes attributes such as `CONTAINER_NAME` and `DEPLOYMENT_ENVIRONMENT`. This provides context to the tracing system.
- The `tracerProvider` is declared in module scope for access in the `stopTracing` function.

3. **Propagator Configuration**:
- A `CompositePropagator` is used to combine multiple propagators (`W3CBaggagePropagator`, `W3CTraceContextPropagator`, and `B3Propagator`) for efficient propagation of tracing context across different systems.

4. **Span Processor Configuration**:
- The `OTLPTraceExporter` is configured with options for exporting traces to a collector endpoint using gRPC.
- A `BatchSpanProcessor` is registered with the tracer provider to handle batch processing of spans before exporting them.

5. **Instrumentation Registration**:
- Various instrumentations (Express, Pino, HTTP, AWS, DNS) are registered with the tracer provider to instrument specific parts of the application.
- Each instrumentation is configured with relevant hooks and settings to ensure accurate and efficient tracing.

6. **Graceful Shutdown**:
- A new `stopTracing` function has been added to gracefully shut down the tracing system by shutting down the tracer provider and ensuring all pending spans are exported before cleanup.

This commit enhances the OpenTelemetry tracing setup by improving logger configuration, tracer provider initialization, propagator combination, span processor configuration, instrumentation registration, and adding a graceful shutdown mechanism. These changes ensure robustness and efficiency in tracing operations within the application.
