### PR TITLE
feat: add context manager async

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^2.0.1",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0",
         "@opentelemetry/instrumentation": "^0.203.0",
         "@opentelemetry/instrumentation-aws-sdk": "^0.57.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saidsef/tracing-node",
-  "version": "3.6.0",
+  "version": "3.7.2",
   "description": "tracing NodeJS - Wrapper for OpenTelemetry instrumentation packages",
   "main": "libs/index.mjs",
   "scripts": {
@@ -31,6 +31,7 @@
   "homepage": "https://github.com/saidsef/tracing-node#readme",
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/context-async-hooks": "^2.0.1",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0",
     "@opentelemetry/instrumentation": "^0.203.0",
     "@opentelemetry/instrumentation-aws-sdk": "^0.57.0",


### PR DESCRIPTION
This pull request updates the tracing setup to improve context propagation and instrumentation configuration for Node.js applications. The main changes include adding support for async hooks-based context management, updating instrumentation options for HTTP and Redis, and bumping the package version.

**Tracing context propagation improvements:**

* Added `@opentelemetry/context-async-hooks` as a dependency and integrated `AsyncHooksContextManager` to enable more reliable context propagation in asynchronous environments (`package.json`, `libs/index.mjs`). [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R34) [[2]](diffhunk://#diff-54ceee9b0469373837fce10a70ba0d28588ed5d1bd784291f6ddb1cfba296752R20) [[3]](diffhunk://#diff-54ceee9b0469373837fce10a70ba0d28588ed5d1bd784291f6ddb1cfba296752R95)

**Instrumentation configuration updates:**

* Modified `HttpInstrumentation` and `IORedisInstrumentation` options to remove strict parent span requirements, allowing for more flexible tracing in distributed systems (`libs/index.mjs`).

**Version update:**

* Bumped the package version from `3.6.0` to `3.7.2` to reflect these improvements (`package.json`).

Resolves: #378 