### PR TITLE
feat(tracing): enhance IORedis with peer service attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saidsef/tracing-node",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "tracing NodeJS - Wrapper for OpenTelemetry instrumentation packages",
   "main": "libs/index.mjs",
   "scripts": {


### PR DESCRIPTION
This pull request enhances distributed tracing support for Redis in the `@saidsef/tracing-node` package, improving service map visualization and consistency of trace metadata. The main changes involve adding and standardizing `peer.service` attributes for Redis spans, updating hooks in the IORedis instrumentation, and incrementing the package version.

### Distributed tracing improvements

* Added logic to detect Redis endpoints and set `peer.service` and `db.system` attributes for Redis spans, ensuring proper identification in distributed tracing tools.
* Updated the IORedis instrumentation to include `peer.service` attributes in both request and response hooks, improving trace metadata consistency for Redis operations.
* Documented that IORedis instrumentation now includes `peer.service` attributes for better service map visualization.

### Package maintenance

* Incremented the package version from `3.9.0` to `3.10.0` in `package.json` to reflect these enhancements.
- Resolves: #425 