### PR TITLE
feat: rework otel bootstrap, add metrics, expand instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ setupTracing({hostname: 'hostname', serviceName: 'service_name', url: 'endpoint'
 |----- | ---- | ------------- | ----- | ---- |
 | hostname | string | container / pod hostname | No | `hostname` |
 | serviceName | string | service / application name | Yes | `n/a` |
-| url | string | tracing endpoint i.e. `<schema>://<host>:<port>` | Yes | `n/a` |
+| url | string | tracing endpoint i.e. `<schema>://<host>:<port>` (with `exporterProtocol: 'http/protobuf'` a missing `/v1/traces` path is auto-appended; with `metricsUrl` the same applies for `/v1/metrics`) | Yes | `n/a` |
 | enableFsInstrumentation | boolean | enable FS instrumentation | No | `false` |
 | enableDnsInstrumentation | boolean | enable DNS instrumentation | No | `false`  |
 | exporterProtocol | `'grpc' \| 'http/protobuf'` | OTLP transport protocol | No | `'grpc'` |
@@ -95,9 +95,31 @@ Disable with `enableMetrics: false` if your collector pipeline does not accept m
 
 The library bundles Postgres, MongoDB, KafkaJS, amqplib and gRPC instrumentations as dependencies, but only **registers** them when the corresponding target library is actually installed in the consuming application (resolved via `require.resolve` from the consumer's `node_modules`). Pass the matching `enable<X>Instrumentation: true|false` flag to override the probe.
 
+## Startup mode (ESM consumers)
+
+For consumers whose `package.json` sets `"type": "module"` (ESM), prefer `--import` over `--require` to load the bootstrap. Node 20.6+ supports `--import`:
+
+```
+node --import ./libs/tracing.mjs app.js
+```
+
+`--require` only patches modules loaded via CJS `require()`. When an ESM caller does `import express from 'express'`, the ESM-to-CJS bridge bypasses `require-in-the-middle`, and instrumentations that target third-party libraries (Express, IORedis, Pino, Postgres, MongoDB, KafkaJS, amqplib, gRPC) silently no-op. The built-in `http` / `https` instrumentation still works because it patches the module object directly, but you lose route names, the middleware-layer span, and any downstream-library spans. The library emits a `console.warn` and sets `startup_mode_degraded: true` in the banner when it detects `--require` without `--import` so this misconfiguration is visible at process start.
+
+CJS consumers can keep using `--require` without consequence.
+
+## Startup banner
+
+Each successful `setupTracing` call emits a single `console.info` line of the form:
+
+```
+[@saidsef/tracing-node] started {"service.name":"...","exporter.protocol":"...","traces.url":"...","metrics.url":"...","instrumentations":[...],"otel_env_overrides":[...]}
+```
+
+It is grep-friendly, ungated, and shows the post-normalisation OTLP URLs plus the names of any `OTEL_*` env vars that were detected as conflicting with the programmatic options (each such conflict also fires its own `console.warn`). Use this to confirm in production logs that the resolved configuration matches the intended one before debugging "no spans reach the collector"-shaped issues.
+
 ## Environment variable support
 
-Bootstrap is performed by `NodeSDK` from `@opentelemetry/sdk-node`. The standard `OTEL_*` environment variables are honoured automatically; programmatic options always take precedence.
+Bootstrap is performed by `NodeSDK` from `@opentelemetry/sdk-node`. The standard `OTEL_*` environment variables are honoured automatically; programmatic options take precedence for `serviceName`, `url`, `metricsUrl`, `exporterProtocol`, and `samplingRatio`, with a `console.warn` emitted when a conflicting env var is set so the override is visible. The resource is built by running the configured detectors and then merging the programmatic `serviceName`/`hostname` over the detected attributes, so `OTEL_SERVICE_NAME` / `OTEL_RESOURCE_ATTRIBUTES` cannot silently overwrite the programmatic `serviceName`.
 
 Relevant vars:
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,20 @@ Effortlessly supercharge your applications with world-class distributed tracing!
 | Feature | Description |
 |---------|-------------|
 | HTTP/HTTPS instrumentation | Automatic service detection |
+| undici (native fetch) instrumentation | Covers Node 18+ `fetch()` and undici clients |
 | Express.js support | Framework instrumentation |
-| Elasticsearch client | Database instrumentation |
 | IORedis client | Cache instrumentation |
 | AWS SDK | Cloud service instrumentation |
 | Pino logger | Integration with trace/span IDs |
 | DNS/FS instrumentation | Optional monitoring |
-| Resource detection | Host, OS, process, container |
+| Resource detection | Host, OS, process, service instance, container/cgroup |
 | W3C Trace Context | Standard propagation |
+| OTLP gRPC and HTTP/protobuf exporters | Selectable via `exporterProtocol` |
+| Configurable head-based sampling | ParentBased + TraceIdRatio |
+| Optional SIGTERM/SIGINT shutdown | Flush spans on signal |
+| Metrics (RED + Node runtime) | OTLP metrics exporter + runtime-node instrumentation, default on |
+| Auto-detected DB / messaging / gRPC instrumentations | Postgres, MongoDB, KafkaJS, amqplib, gRPC — enabled only if the target lib is installed in the consuming app |
+| `NodeSDK` bootstrap | Built on `@opentelemetry/sdk-node`; honours standard `OTEL_*` env vars |
 
 ## Prerequisites
 - NodeJS
@@ -62,6 +68,54 @@ setupTracing({hostname: 'hostname', serviceName: 'service_name', url: 'endpoint'
 | url | string | tracing endpoint i.e. `<schema>://<host>:<port>` | Yes | `n/a` |
 | enableFsInstrumentation | boolean | enable FS instrumentation | No | `false` |
 | enableDnsInstrumentation | boolean | enable DNS instrumentation | No | `false`  |
+| exporterProtocol | `'grpc' \| 'http/protobuf'` | OTLP transport protocol | No | `'grpc'` |
+| samplingRatio | number (0.0-1.0) | head-based sampling ratio for root spans; child spans follow parent | No | `1.0` |
+| installSignalHandlers | boolean | register SIGTERM/SIGINT handlers that flush spans and exit | No | `false` |
+| enableDiagLogging | boolean | enable OTel diagnostic console logger (also honoured via `OTEL_LOG_LEVEL` env) | No | `false` |
+| enableMetrics | boolean | configure a global MeterProvider so instrumentations emit RED-method metrics + Node runtime metrics | No | `true` |
+| metricsUrl | string | OTLP metrics endpoint override | No | `url` |
+| metricExportIntervalMillis | number | periodic metrics export interval | No | `60000` |
+| enableGrpcInstrumentation | boolean | force on/off; omit for auto-detect via `@grpc/grpc-js` probe | No | auto |
+| enablePgInstrumentation | boolean | force on/off; omit for auto-detect via `pg` probe | No | auto |
+| enableMongoDBInstrumentation | boolean | force on/off; omit for auto-detect via `mongodb` probe | No | auto |
+| enableKafkaJsInstrumentation | boolean | force on/off; omit for auto-detect via `kafkajs` probe | No | auto |
+| enableAmqplibInstrumentation | boolean | force on/off; omit for auto-detect via `amqplib` probe | No | auto |
+
+## Metrics
+
+When `enableMetrics` is true (default), a `MeterProvider` is registered globally with a `PeriodicExportingMetricReader` pointing at `metricsUrl` (or `url`). All existing instrumentations that emit OTel metrics will start producing them automatically:
+
+- `http.server.duration`, `http.client.duration` histograms from `instrumentation-http` and `instrumentation-undici`
+- AWS SDK / IORedis / Express durations
+- Node runtime: `nodejs.eventloop.delay.*`, `nodejs.gc.duration`, `nodejs.heap.*` from `instrumentation-runtime-node`
+
+Disable with `enableMetrics: false` if your collector pipeline does not accept metrics.
+
+## Auto-detected instrumentations
+
+The library bundles Postgres, MongoDB, KafkaJS, amqplib and gRPC instrumentations as dependencies, but only **registers** them when the corresponding target library is actually installed in the consuming application (resolved via `require.resolve` from the consumer's `node_modules`). Pass the matching `enable<X>Instrumentation: true|false` flag to override the probe.
+
+## Environment variable support
+
+Bootstrap is performed by `NodeSDK` from `@opentelemetry/sdk-node`. The standard `OTEL_*` environment variables are honoured automatically; programmatic options always take precedence.
+
+Relevant vars:
+
+| Variable | Effect |
+|---|---|
+| `OTEL_SDK_DISABLED=true` | Disables the SDK entirely |
+| `OTEL_LOG_LEVEL` | Diagnostic log level (`NONE`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `VERBOSE`, `ALL`) |
+| `OTEL_SERVICE_NAME` | Service name fallback if `serviceName` option / `SERVICE_NAME` env are unset |
+| `OTEL_RESOURCE_ATTRIBUTES` | Comma-separated `key=value` pairs merged into the resource |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP endpoint fallback if `url` option / `ENDPOINT` env are unset |
+| `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`, `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` | Protocol selection fallback |
+| `OTEL_METRIC_EXPORT_INTERVAL`, `OTEL_METRIC_EXPORT_TIMEOUT` | Metric reader timing fallbacks |
+| `OTEL_PROPAGATORS` | Comma-separated propagator list; if unset, defaults to W3C TraceContext + Baggage |
+| `OTEL_NODE_RESOURCE_DETECTORS` | Subset of detectors to run (`env`, `host`, `os`, `process`, `serviceinstance`, `all`, `none`) |
+
+## Roadmap
+
+- Logs SDK (`@opentelemetry/sdk-logs`) + OTLP logs exporter
 
 ## Source
 

--- a/libs/index.mjs
+++ b/libs/index.mjs
@@ -16,36 +16,65 @@
  * limitations under the License.
  */
 
+import {createRequire} from 'node:module';
+import {AmqplibInstrumentation} from '@opentelemetry/instrumentation-amqplib';
 import {AwsInstrumentation} from '@opentelemetry/instrumentation-aws-sdk';
-import {AsyncHooksContextManager} from '@opentelemetry/context-async-hooks';
-import {BatchSpanProcessor} from '@opentelemetry/sdk-trace-base';
+import {AsyncLocalStorageContextManager} from '@opentelemetry/context-async-hooks';
+import {BatchSpanProcessor, ParentBasedSampler, TraceIdRatioBasedSampler} from '@opentelemetry/sdk-trace-base';
 import {CompositePropagator, W3CBaggagePropagator, W3CTraceContextPropagator} from '@opentelemetry/core';
-import {ConnectInstrumentation} from '@opentelemetry/instrumentation-connect';
-import {diag, DiagConsoleLogger, DiagLogLevel} from '@opentelemetry/api';
+import {containerDetector} from '@opentelemetry/resource-detector-container';
+import {diag, DiagConsoleLogger, DiagLogLevel, metrics, trace} from '@opentelemetry/api';
+import {GrpcInstrumentation} from '@opentelemetry/instrumentation-grpc';
 import {HttpInstrumentation} from '@opentelemetry/instrumentation-http';
 import {DnsInstrumentation} from '@opentelemetry/instrumentation-dns';
-import {ElasticsearchInstrumentation} from 'opentelemetry-instrumentation-elasticsearch';
 import {ExpressInstrumentation} from '@opentelemetry/instrumentation-express';
-import {NodeTracerProvider} from '@opentelemetry/sdk-trace-node';
-import {OTLPTraceExporter} from '@opentelemetry/exporter-trace-otlp-grpc';
+import {KafkaJsInstrumentation} from '@opentelemetry/instrumentation-kafkajs';
+import {NodeSDK} from '@opentelemetry/sdk-node';
+import {MongoDBInstrumentation} from '@opentelemetry/instrumentation-mongodb';
+import {OTLPMetricExporter as OTLPGrpcMetricExporter} from '@opentelemetry/exporter-metrics-otlp-grpc';
+import {OTLPMetricExporter as OTLPHttpProtoMetricExporter} from '@opentelemetry/exporter-metrics-otlp-proto';
+import {OTLPTraceExporter as OTLPGrpcTraceExporter} from '@opentelemetry/exporter-trace-otlp-grpc';
+import {OTLPTraceExporter as OTLPHttpProtoTraceExporter} from '@opentelemetry/exporter-trace-otlp-proto';
+import {PeriodicExportingMetricReader} from '@opentelemetry/sdk-metrics';
+import {PgInstrumentation} from '@opentelemetry/instrumentation-pg';
 import {PinoInstrumentation} from '@opentelemetry/instrumentation-pino';
 import {IORedisInstrumentation} from '@opentelemetry/instrumentation-ioredis';
-import {registerInstrumentations} from '@opentelemetry/instrumentation';
+import {RuntimeNodeInstrumentation} from '@opentelemetry/instrumentation-runtime-node';
+import {UndiciInstrumentation} from '@opentelemetry/instrumentation-undici';
 import {FsInstrumentation} from '@opentelemetry/instrumentation-fs';
-import {resourceFromAttributes, detectResources, envDetector, hostDetector, osDetector, processDetector, serviceInstanceIdDetector} from '@opentelemetry/resources';
+import {resourceFromAttributes, envDetector, hostDetector, osDetector, processDetector, serviceInstanceIdDetector} from '@opentelemetry/resources';
 import {ATTR_SERVICE_NAME} from '@opentelemetry/semantic-conventions';
 import {ATTR_CONTAINER_NAME} from '@opentelemetry/semantic-conventions/incubating';
 
-diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
+const requireFromConsumer = createRequire(import.meta.url);
+const targetInstalled = (name) => {
+  try { requireFromConsumer.resolve(name); return true; } catch { return false; }
+};
+
+const DIAG_LEVELS = {
+  NONE: DiagLogLevel.NONE,
+  ERROR: DiagLogLevel.ERROR,
+  WARN: DiagLogLevel.WARN,
+  INFO: DiagLogLevel.INFO,
+  DEBUG: DiagLogLevel.DEBUG,
+  VERBOSE: DiagLogLevel.VERBOSE,
+  ALL: DiagLogLevel.ALL,
+};
 
 /**
-* Sets up tracing for the application using OpenTelemetry.
+* Sets up tracing for the application using OpenTelemetry's NodeSDK.
 *
-* This function configures a NodeTracerProvider with various instrumentations
-* and span processors to enable tracing for the application. It supports
-* tracing for HTTP, Express, AWS, Pino, DNS, Elasticsearch, and IORedis.
-* The IORedis instrumentation includes peer.service attributes for proper
-* service map visualization in distributed tracing tools like Tempo.
+* Bootstraps `@opentelemetry/sdk-node` `NodeSDK` with traces (BatchSpanProcessor),
+* optional metrics (PeriodicExportingMetricReader + Node runtime metrics),
+* ParentBased TraceIdRatio sampling, AsyncLocalStorage context, W3C TraceContext
+* + Baggage propagation, and instrumentations for HTTP, undici (native fetch),
+* Express, AWS SDK, IORedis, Pino, plus auto-detected gRPC / Postgres / MongoDB
+* / KafkaJS / amqplib when their target libraries are installed in the consumer.
+*
+* The full set of standard `OTEL_*` environment variables is honoured via
+* NodeSDK (e.g. `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_RESOURCE_ATTRIBUTES`,
+* `OTEL_PROPAGATORS`, `OTEL_SDK_DISABLED`). Programmatic options take
+* precedence over environment variables.
 *
 * @param {Object} options - Configuration options for tracing.
 * @param {string} [options.hostname=process.env.HOSTNAME] - The hostname of the service.
@@ -54,16 +83,28 @@ diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
 * @param {number} [options.concurrencyLimit=10] - The concurrency limit for the exporter.
 * @param {boolean} [options.enableFsInstrumentation=false] - Enable file system instrumentation.
 * @param {boolean} [options.enableDnsInstrumentation=false] - Enable DNS instrumentation.
+* @param {('grpc'|'http/protobuf')} [options.exporterProtocol='grpc'] - OTLP exporter protocol.
+* @param {number} [options.samplingRatio=1.0] - Head-based sampling ratio for root spans (0.0-1.0). Inherits parent decision via ParentBasedSampler.
+* @param {boolean} [options.installSignalHandlers=false] - Register SIGTERM/SIGINT handlers that flush spans and exit.
+* @param {boolean} [options.enableDiagLogging=false] - Enable OpenTelemetry diagnostic console logger. Also enabled if OTEL_LOG_LEVEL env var is set.
+* @param {boolean} [options.enableMetrics=true] - Configure a MeterProvider so existing instrumentations emit RED-method metrics, plus Node runtime metrics.
+* @param {string} [options.metricsUrl] - OTLP metrics endpoint. Defaults to `url`.
+* @param {number} [options.metricExportIntervalMillis=60000] - Periodic metric reader export interval.
+* @param {boolean} [options.enableGrpcInstrumentation] - Force on/off; undefined = auto-detect by probing `@grpc/grpc-js`.
+* @param {boolean} [options.enablePgInstrumentation] - Force on/off; undefined = auto-detect by probing `pg`.
+* @param {boolean} [options.enableMongoDBInstrumentation] - Force on/off; undefined = auto-detect by probing `mongodb`.
+* @param {boolean} [options.enableKafkaJsInstrumentation] - Force on/off; undefined = auto-detect by probing `kafkajs`.
+* @param {boolean} [options.enableAmqplibInstrumentation] - Force on/off; undefined = auto-detect by probing `amqplib`.
 *
 * @returns {Tracer} - The tracer for the service.
 */
-let tracerProvider = null; // Declare provider in module scope for access in stopTracing
+let sdk = null;
+let signalHandlers = null;
 
 export function setupTracing(options = {}) {
-  // Prevent multiple initializations - return existing provider if already set up
-  if (tracerProvider) {
+  if (sdk) {
     console.warn('Tracing is already initialized. Returning existing tracer.');
-    return tracerProvider.getTracer(options.serviceName || process.env.SERVICE_NAME);
+    return trace.getTracer(options.serviceName || process.env.SERVICE_NAME);
   }
 
   const {
@@ -73,107 +114,114 @@ export function setupTracing(options = {}) {
     concurrencyLimit = 10,
     enableFsInstrumentation = false,
     enableDnsInstrumentation = false,
+    exporterProtocol = 'grpc',
+    samplingRatio = 1.0,
+    installSignalHandlers = false,
+    enableDiagLogging = false,
+    enableMetrics = true,
+    metricsUrl,
+    metricExportIntervalMillis = 60000,
+    enableGrpcInstrumentation,
+    enablePgInstrumentation,
+    enableMongoDBInstrumentation,
+    enableKafkaJsInstrumentation,
+    enableAmqplibInstrumentation,
   } = options;
 
-  // Validate required parameters
   if (!serviceName) {
     throw new Error('serviceName is required');
   }
   if (!url) {
     throw new Error('url is required');
   }
+  if (exporterProtocol !== 'grpc' && exporterProtocol !== 'http/protobuf') {
+    throw new Error(`exporterProtocol must be 'grpc' or 'http/protobuf', got: ${exporterProtocol}`);
+  }
+  if (typeof samplingRatio !== 'number' || samplingRatio < 0 || samplingRatio > 1) {
+    throw new Error(`samplingRatio must be a number between 0 and 1, got: ${samplingRatio}`);
+  }
 
-  // Configure exporter with the Collector endpoint - uses gRPC
+  const envLevel = process.env.OTEL_LOG_LEVEL && DIAG_LEVELS[process.env.OTEL_LOG_LEVEL.toUpperCase()];
+  if (enableDiagLogging || envLevel !== undefined) {
+    diag.setLogger(new DiagConsoleLogger(), envLevel ?? DiagLogLevel.INFO);
+  }
+
   const exportOptions = {
     concurrencyLimit,
     url,
     timeoutMillis: 10000,
   };
+  const TraceExporterCtor = exporterProtocol === 'http/protobuf' ? OTLPHttpProtoTraceExporter : OTLPGrpcTraceExporter;
+  const traceExporter = new TraceExporterCtor(exportOptions);
 
-  // Register the span processor with the tracer provider
-  const exporter = new OTLPTraceExporter(exportOptions);
-
-  // Configure BatchSpanProcessor for production workloads
-  const spanProcessor = new BatchSpanProcessor(exporter, {
+  const spanProcessor = new BatchSpanProcessor(traceExporter, {
     maxQueueSize: 4096,
     maxExportBatchSize: 1024,
     scheduledDelayMillis: 2000,
     exportTimeoutMillis: 10000,
   });
 
-  tracerProvider = new NodeTracerProvider({
-    spanProcessors: [spanProcessor],
-    resource: new resourceFromAttributes({
-      [ATTR_SERVICE_NAME]: serviceName,
-      [ATTR_CONTAINER_NAME]: hostname,
-    }).merge(
-      detectResources({
-        detectors: [envDetector, hostDetector, osDetector, processDetector, serviceInstanceIdDetector],
-      })
-    ),
-    autoDetectResources: true,
+  const resource = resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: serviceName,
+    [ATTR_CONTAINER_NAME]: hostname,
   });
 
-  // Initialize the tracer provider with propagators
-  tracerProvider.register({
-    contextManager: new AsyncHooksContextManager().enable(),
-    propagator: new CompositePropagator({
-    propagators: [
-      new W3CTraceContextPropagator(),
-      new W3CBaggagePropagator(),
-      ],
-    }),
-  });
+  let metricReaders = [];
+  if (enableMetrics) {
+    const MetricExporterCtor = exporterProtocol === 'http/protobuf' ? OTLPHttpProtoMetricExporter : OTLPGrpcMetricExporter;
+    const metricExporter = new MetricExporterCtor({
+      url: metricsUrl || url,
+      concurrencyLimit,
+      timeoutMillis: 10000,
+    });
+    metricReaders = [
+      new PeriodicExportingMetricReader({
+        exporter: metricExporter,
+        exportIntervalMillis: metricExportIntervalMillis,
+      }),
+    ];
+  }
 
-  // Ignore spans from static assets.
   const ignoreIncomingRequestHook = (req) => {
     return req.url.startsWith('/metrics') || req.url.startsWith('/healthz');
   };
 
-  // Hook to set peer service name for outgoing requests
   const applyCustomAttributesOnSpan = (span, request) => {
-    const url = request?.url || request?.uri || '';
-    const hostname = request?.hostname || request?.host || '';
-    
-    // Detect Elasticsearch endpoints
-    if (hostname.includes('elasticsearch') || url.includes('elasticsearch') || 
-        hostname.includes(':9200') || url.includes(':9200')) {
+    const reqUrl = request?.url || request?.uri || '';
+    const reqHostname = request?.hostname || request?.host || '';
+
+    if (reqHostname.includes('elasticsearch') || reqUrl.includes('elasticsearch') ||
+        reqHostname.includes(':9200') || reqUrl.includes(':9200')) {
       span.setAttribute('peer.service', 'elasticsearch');
       span.setAttribute('db.system', 'elasticsearch');
     }
 
-    // Detect Redis endpoints
-    if (hostname.includes('redis') || url.includes('redis') || 
-        hostname.includes(':6379') || url.includes(':6379')) {
+    if (reqHostname.includes('redis') || reqUrl.includes('redis') ||
+        reqHostname.includes(':6379') || reqUrl.includes(':6379')) {
       span.setAttribute('peer.service', 'redis');
       span.setAttribute('db.system', 'redis');
     }
   };
 
-  // Register instrumentations
   const instrumentations = [
     new HttpInstrumentation({
       serverName: serviceName,
       ignoreIncomingRequestHook,
       applyCustomAttributesOnSpan,
       requestHook: (span, request) => {
-        // Enrich spans with additional HTTP request attributes
         if (!request.headers) return;
 
         const headers = request.headers;
 
-        // Safe header extraction with case-insensitive fallback
         const userAgent = headers['user-agent'] || headers['User-Agent'];
         const contentType = headers['content-type'] || headers['Content-Type'];
         const contentLength = headers['content-length'] || headers['Content-Length'];
         const requestId = headers['x-request-id'] || headers['X-Request-ID'];
         const correlationId = headers['x-correlation-id'] || headers['X-Correlation-ID'];
 
-        // Only set attributes if values exist
         if (userAgent) span.setAttribute('http.user_agent', userAgent);
         if (contentType) span.setAttribute('http.request.content_type', contentType);
 
-        // Safe integer parsing with validation
         if (contentLength) {
           const length = parseInt(contentLength, 10);
           if (!Number.isNaN(length) && length >= 0) {
@@ -181,12 +229,10 @@ export function setupTracing(options = {}) {
           }
         }
 
-        // Correlation headers for distributed tracing
         if (requestId) span.setAttribute('http.request_id', requestId);
         if (correlationId) span.setAttribute('http.correlation_id', correlationId);
       },
       responseHook: (span, response) => {
-        // Add response attributes for better observability
         if (!response.headers) return;
 
         const headers = response.headers;
@@ -206,10 +252,31 @@ export function setupTracing(options = {}) {
         if (requestId) span.setAttribute('http.request_id', requestId);
       },
     }),
+    new UndiciInstrumentation({
+      ignoreRequestHook: (request) => {
+        const path = request?.path || '';
+        return path.startsWith('/metrics') || path.startsWith('/healthz');
+      },
+      requestHook: (span, request) => {
+        const headers = request?.headers;
+        if (!headers) return;
+        const headerMap = Array.isArray(headers)
+          ? Object.fromEntries(
+              headers
+                .map((line) => typeof line === 'string' ? line.split(':') : null)
+                .filter((kv) => kv && kv.length >= 2)
+                .map(([k, ...rest]) => [k.trim().toLowerCase(), rest.join(':').trim()])
+            )
+          : headers;
+        const requestId = headerMap['x-request-id'];
+        const correlationId = headerMap['x-correlation-id'];
+        if (requestId) span.setAttribute('http.request_id', requestId);
+        if (correlationId) span.setAttribute('http.correlation_id', correlationId);
+      },
+    }),
     new ExpressInstrumentation({
       ignoreIncomingRequestHook,
       requestHook: (span, request) => {
-        // Add Express-specific attributes
         if (request.route?.path) {
           span.setAttribute('express.route', request.route.path);
           span.updateName(`${request.method} ${request.route.path}`);
@@ -220,7 +287,6 @@ export function setupTracing(options = {}) {
         if (request.query && Object.keys(request.query).length > 0) {
           span.setAttribute('express.query', JSON.stringify(request.query));
         }
-        // Add user context if available
         if (request.user?.id) {
           span.setAttribute('user.id', request.user.id);
         }
@@ -228,13 +294,11 @@ export function setupTracing(options = {}) {
     }),
     new PinoInstrumentation({
       logHook: (span, record) => {
-        // Inject trace context into log records
         const spanContext = span.spanContext();
         record['trace_id'] = spanContext.traceId;
         record['span_id'] = spanContext.spanId;
         record['trace_flags'] = `0${spanContext.traceFlags.toString(16)}`;
 
-        // Add service name for better log correlation
         if (serviceName) {
           record['service.name'] = serviceName;
         }
@@ -247,31 +311,17 @@ export function setupTracing(options = {}) {
         trace: 'TRACE',
       },
     }),
-    new ConnectInstrumentation({
-      ignoreIncomingRequestHook,
-      requestHook: (span, request) => {
-        // Add Connect middleware attributes
-        if (request.url) {
-          span.setAttribute('connect.url', request.url);
-        }
-        if (request.method) {
-          span.setAttribute('connect.method', request.method);
-        }
-      },
-    }),
     new AwsInstrumentation({
       suppressInternalInstrumentation: false,
       sqsExtractContextPropagationFromPayload: true,
       preRequestHook: (span, request) => {
-        // Add peer.service attribute for better service map visualization
-        const serviceName = request.serviceName || request.service?.serviceIdentifier;
-        if (serviceName) {
-          span.setAttribute('peer.service', serviceName.toLowerCase());
-          span.setAttribute('aws.service', serviceName.toLowerCase());
+        const awsServiceName = request.serviceName || request.service?.serviceIdentifier;
+        if (awsServiceName) {
+          span.setAttribute('peer.service', awsServiceName.toLowerCase());
+          span.setAttribute('aws.service', awsServiceName.toLowerCase());
         }
       },
       responseHook: (span, response) => {
-        // Add additional attributes from response if available
         if (response?.requestId) {
           span.setAttribute('aws.request_id', response.requestId);
         }
@@ -280,44 +330,35 @@ export function setupTracing(options = {}) {
     new IORedisInstrumentation({
       requireParentSpan: false,
       requestHook: (span, cmdName, cmdArgs) => {
-        // Set peer.service for service graph visualization - CRITICAL for Tempo
         span.setAttribute('peer.service', 'redis');
         span.setAttribute('db.system', 'redis');
-        
-        // CRITICAL: Ensure span kind is CLIENT for service graph
+
         span.setAttribute('span.kind', 'CLIENT');
-        
-        // Add network peer attributes (helps Tempo identify the service)
+
         span.setAttribute('net.peer.name', 'redis');
         span.setAttribute('db.connection_string', 'redis');
 
-        // Add command details for better observability
         if (cmdName) {
           span.setAttribute('db.operation', cmdName.toUpperCase());
           span.updateName(`redis.${cmdName.toUpperCase()}`);
         }
 
-        // Add key information (first argument is usually the key)
         if (cmdArgs && cmdArgs.length > 0) {
           span.setAttribute('db.redis.key', String(cmdArgs[0]));
 
-          // For operations with multiple keys or complex args
           if (cmdArgs.length > 1) {
             span.setAttribute('db.redis.args_count', cmdArgs.length);
           }
         }
       },
       responseHook: (span, cmdName, cmdArgs, response) => {
-        // Ensure peer.service persists through response
         span.setAttribute('peer.service', 'redis');
         span.setAttribute('db.system', 'redis');
 
-        // Add command details for better observability
         if (cmdName) {
           span.setAttribute('db.operation', cmdName.toUpperCase());
         }
 
-        // Log response size if available
         if (response !== undefined && response !== null) {
           const responseType = typeof response;
           span.setAttribute('db.response.type', responseType);
@@ -328,7 +369,6 @@ export function setupTracing(options = {}) {
         }
       },
       dbStatementSerializer: (cmdName, cmdArgs) => {
-        // Serialize command for better observability (limit arg length to avoid huge spans)
         const args = cmdArgs.map(arg => {
           const str = String(arg);
           return str.length > 100 ? `${str.substring(0, 100)}...` : str;
@@ -336,22 +376,73 @@ export function setupTracing(options = {}) {
         return `${cmdName} ${args.join(' ')}`;
       },
     }),
-    new ElasticsearchInstrumentation(),
   ];
 
+  const shouldEnable = (override, target) => {
+    if (override === true) return true;
+    if (override === false) return false;
+    return targetInstalled(target);
+  };
+
+  if (enableMetrics) {
+    instrumentations.push(new RuntimeNodeInstrumentation());
+  }
+
+  if (shouldEnable(enableGrpcInstrumentation, '@grpc/grpc-js')) {
+    instrumentations.push(new GrpcInstrumentation());
+  }
+  if (shouldEnable(enablePgInstrumentation, 'pg')) {
+    instrumentations.push(new PgInstrumentation({
+      requireParentSpan: false,
+      enhancedDatabaseReporting: true,
+      requestHook: (span) => {
+        span.setAttribute('peer.service', 'postgres');
+        span.setAttribute('db.system', 'postgresql');
+      },
+    }));
+  }
+  if (shouldEnable(enableMongoDBInstrumentation, 'mongodb')) {
+    instrumentations.push(new MongoDBInstrumentation({
+      enhancedDatabaseReporting: false,
+      responseHook: (span) => {
+        span.setAttribute('peer.service', 'mongodb');
+        span.setAttribute('db.system', 'mongodb');
+      },
+    }));
+  }
+  if (shouldEnable(enableKafkaJsInstrumentation, 'kafkajs')) {
+    instrumentations.push(new KafkaJsInstrumentation({
+      producerHook: (span) => {
+        span.setAttribute('peer.service', 'kafka');
+        span.setAttribute('messaging.system', 'kafka');
+      },
+      consumerHook: (span) => {
+        span.setAttribute('peer.service', 'kafka');
+        span.setAttribute('messaging.system', 'kafka');
+      },
+    }));
+  }
+  if (shouldEnable(enableAmqplibInstrumentation, 'amqplib')) {
+    instrumentations.push(new AmqplibInstrumentation({
+      publishHook: (span) => {
+        span.setAttribute('peer.service', 'rabbitmq');
+        span.setAttribute('messaging.system', 'rabbitmq');
+      },
+      consumeHook: (span) => {
+        span.setAttribute('peer.service', 'rabbitmq');
+        span.setAttribute('messaging.system', 'rabbitmq');
+      },
+    }));
+  }
+
   if (enableFsInstrumentation) {
-    // Enable fs instrumentation if specified
-    // This instrumentation is useful for tracing file system operations.
     instrumentations.push(new FsInstrumentation());
   }
 
   if (enableDnsInstrumentation) {
-    // Enable DNS instrumentation if specified
-    // This instrumentation is useful for tracing DNS operations.
     instrumentations.push(new DnsInstrumentation({
       ignoreHostnames: ['localhost', '127.0.0.1', '::1'],
       requestHook: (span, request) => {
-        // Add DNS query details for better observability
         if (request.hostname) {
           span.setAttribute('dns.hostname', request.hostname);
           span.updateName(`DNS ${request.hostname}`);
@@ -359,16 +450,13 @@ export function setupTracing(options = {}) {
         if (request.rrtype) {
           span.setAttribute('dns.record_type', request.rrtype);
         }
-        // Add additional context
         span.setAttribute('peer.service', 'dns');
         span.setAttribute('dns.query_count', 1);
       },
       responseHook: (span, response) => {
-        // Add DNS response details
         if (Array.isArray(response)) {
           span.setAttribute('dns.result_count', response.length);
-          // Log first few results for debugging (limit to avoid overwhelming spans)
-          const resultSample = response.slice(0, 3).map(r => 
+          const resultSample = response.slice(0, 3).map(r =>
             typeof r === 'string' ? r : JSON.stringify(r)
           );
           if (resultSample.length > 0) {
@@ -380,13 +468,11 @@ export function setupTracing(options = {}) {
         }
       },
       errorHook: (span, error) => {
-        // Enhanced error tracking for DNS failures
         if (error) {
           span.setAttribute('dns.error', true);
           span.setAttribute('dns.error.code', error.code || 'UNKNOWN');
           span.setAttribute('dns.error.message', error.message || 'DNS lookup failed');
 
-          // Categorize common DNS errors
           if (error.code === 'ENOTFOUND') {
             span.setAttribute('dns.error.type', 'NOT_FOUND');
           } else if (error.code === 'ETIMEOUT') {
@@ -401,44 +487,81 @@ export function setupTracing(options = {}) {
     }));
   }
 
-  // Register instrumentations
-  registerInstrumentations({
-    tracerProvider: tracerProvider,
-    instrumentations: instrumentations,
+  sdk = new NodeSDK({
+    serviceName,
+    resource,
+    autoDetectResources: true,
+    resourceDetectors: [envDetector, hostDetector, osDetector, processDetector, serviceInstanceIdDetector, containerDetector],
+    sampler: new ParentBasedSampler({
+      root: new TraceIdRatioBasedSampler(samplingRatio),
+    }),
+    contextManager: new AsyncLocalStorageContextManager(),
+    textMapPropagator: new CompositePropagator({
+      propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()],
+    }),
+    spanProcessors: [spanProcessor],
+    metricReaders,
+    instrumentations,
   });
+  sdk.start();
 
-  // Return the tracer for the service
-  return tracerProvider.getTracer(serviceName);
+  if (installSignalHandlers && !signalHandlers) {
+    const handler = () => {
+      stopTracing().finally(() => process.exit(0));
+    };
+    signalHandlers = {SIGTERM: handler, SIGINT: handler};
+    process.once('SIGTERM', handler);
+    process.once('SIGINT', handler);
+  }
+
+  return trace.getTracer(serviceName);
 }
 
 /**
-* Gracefully stops the tracing by shutting down the tracer provider.
+* Gracefully stops the tracing by shutting down the NodeSDK.
 *
-* This function ensures that all pending spans are exported and resources are
-* cleaned up properly. It is recommended to call this function during the
-* application's shutdown process.
+* Flushes pending spans and metrics via `sdk.shutdown()`, then releases the
+* global tracer / meter provider registrations on the OpenTelemetry API so a
+* subsequent `setupTracing()` call can register fresh providers (the API's
+* `setGlobalMeterProvider` and `setGlobalTracerProvider` are lock-once
+* without an explicit `disable()` call).
 *
 * @returns {Promise<void>} - A promise that resolves when shutdown is complete.
 */
 export async function stopTracing() {
-  if (tracerProvider) {
-    try {
-      await tracerProvider.shutdown();
-      tracerProvider = null;
-      console.info('Tracing has been successfully shut down.');
-    } catch (error) {
-      console.error('Error during tracing shutdown:', error);
-    }
-  } else {
+  if (signalHandlers) {
+    process.removeListener('SIGTERM', signalHandlers.SIGTERM);
+    process.removeListener('SIGINT', signalHandlers.SIGINT);
+    signalHandlers = null;
+  }
+  if (!sdk) {
     console.warn('Tracer provider is not initialized.');
+    return;
+  }
+  try {
+    await sdk.shutdown();
+    console.info('Tracing has been successfully shut down.');
+  } catch (error) {
+    console.error('Error during tracing shutdown:', error);
+  } finally {
+    metrics.disable();
+    trace.disable();
+    sdk = null;
   }
 }
 
 /**
  * @internal
- * Resets the tracer provider for testing purposes.
+ * Resets the SDK for testing purposes.
  * DO NOT use in production code.
  */
 export function __resetTracingForTesting() {
-  tracerProvider = null;
+  if (signalHandlers) {
+    process.removeListener('SIGTERM', signalHandlers.SIGTERM);
+    process.removeListener('SIGINT', signalHandlers.SIGINT);
+    signalHandlers = null;
+  }
+  metrics.disable();
+  trace.disable();
+  sdk = null;
 }

--- a/libs/index.mjs
+++ b/libs/index.mjs
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import {createRequire} from 'node:module';
+import {createRequire, register as registerLoader} from 'node:module';
 import {AmqplibInstrumentation} from '@opentelemetry/instrumentation-amqplib';
 import {AwsInstrumentation} from '@opentelemetry/instrumentation-aws-sdk';
 import {AsyncLocalStorageContextManager} from '@opentelemetry/context-async-hooks';
@@ -42,7 +42,7 @@ import {IORedisInstrumentation} from '@opentelemetry/instrumentation-ioredis';
 import {RuntimeNodeInstrumentation} from '@opentelemetry/instrumentation-runtime-node';
 import {UndiciInstrumentation} from '@opentelemetry/instrumentation-undici';
 import {FsInstrumentation} from '@opentelemetry/instrumentation-fs';
-import {resourceFromAttributes, envDetector, hostDetector, osDetector, processDetector, serviceInstanceIdDetector} from '@opentelemetry/resources';
+import {resourceFromAttributes, detectResources, envDetector, hostDetector, osDetector, processDetector, serviceInstanceIdDetector} from '@opentelemetry/resources';
 import {ATTR_SERVICE_NAME} from '@opentelemetry/semantic-conventions';
 import {ATTR_CONTAINER_NAME} from '@opentelemetry/semantic-conventions/incubating';
 
@@ -50,6 +50,24 @@ const requireFromConsumer = createRequire(import.meta.url);
 const targetInstalled = (name) => {
   try { requireFromConsumer.resolve(name); return true; } catch { return false; }
 };
+
+// Register the import-in-the-middle loader hook so ESM consumers' static
+// `import` statements get patched by instrumentations that target third-party
+// CJS modules (Express, IORedis, Pino, Postgres, MongoDB, KafkaJS, amqplib,
+// gRPC). Must happen here at module-load time of this library — i.e. before
+// the consumer's app code is linked — so it's effective when the bootstrap is
+// loaded via `node --import ./tracing.mjs app.js`. Without this, --import
+// alone is no better than --require for ESM auto-instrumentation: HTTP works
+// (it patches the built-in module object directly) but everything else silently
+// no-ops. Safe to call from a CJS consumer too: the loader is benign and
+// require-in-the-middle continues to handle the CJS require() path.
+if (typeof registerLoader === 'function') {
+  try {
+    registerLoader('@opentelemetry/instrumentation/hook.mjs', import.meta.url);
+  } catch (err) {
+    diag.debug?.('[@saidsef/tracing-node] could not register ESM loader hook:', err);
+  }
+}
 
 const DIAG_LEVELS = {
   NONE: DiagLogLevel.NONE,
@@ -60,6 +78,71 @@ const DIAG_LEVELS = {
   VERBOSE: DiagLogLevel.VERBOSE,
   ALL: DiagLogLevel.ALL,
 };
+
+const OTLP_HTTP_TRACES_PATH = '/v1/traces';
+const OTLP_HTTP_METRICS_PATH = '/v1/metrics';
+
+function normaliseOtlpHttpUrl(url, signalPath) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return {url, rewritten: false};
+  }
+  const path = parsed.pathname.replace(/\/$/, '');
+  if (path === signalPath || path.endsWith(signalPath)) {
+    return {url: parsed.href, rewritten: false};
+  }
+  parsed.pathname = (path === '' ? '' : path) + signalPath;
+  return {url: parsed.href, rewritten: true};
+}
+
+const CONFLICT_ENV_KEYS = [
+  'OTEL_SDK_DISABLED',
+  'OTEL_SERVICE_NAME',
+  'OTEL_RESOURCE_ATTRIBUTES',
+  'OTEL_EXPORTER_OTLP_ENDPOINT',
+  'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT',
+  'OTEL_EXPORTER_OTLP_METRICS_ENDPOINT',
+  'OTEL_EXPORTER_OTLP_PROTOCOL',
+  'OTEL_EXPORTER_OTLP_TRACES_PROTOCOL',
+  'OTEL_EXPORTER_OTLP_METRICS_PROTOCOL',
+  'OTEL_TRACES_SAMPLER',
+  'OTEL_TRACES_SAMPLER_ARG',
+];
+
+function detectDegradedStartupMode() {
+  const execArgv = Array.isArray(process.execArgv) ? process.execArgv : [];
+  const hasRequire = execArgv.some((a) => a === '--require' || a === '-r' || a.startsWith('--require=') || a.startsWith('-r='));
+  const hasImport = execArgv.some((a) => a === '--import' || a.startsWith('--import='));
+  if (hasRequire && !hasImport) {
+    return 'startup uses --require but not --import; ESM auto-instrumentation (e.g. Express, IORedis) cannot be hooked via --require. Prefer `node --import ./tracing.mjs app.js` (Node 20.6+). HTTP built-in instrumentation still works either way.';
+  }
+  return null;
+}
+
+function detectConflictingOtelEnv(resolved) {
+  const findings = [];
+  for (const key of CONFLICT_ENV_KEYS) {
+    const value = process.env[key];
+    if (value == null || value === '') continue;
+    if (key === 'OTEL_RESOURCE_ATTRIBUTES' && !/\bservice\.name\s*=/i.test(value)) continue;
+
+    let conflictsWith = null;
+    if (key === 'OTEL_SDK_DISABLED' && /^true$/i.test(value)) conflictsWith = 'setupTracing call (SDK would be disabled by env)';
+    else if (key === 'OTEL_SERVICE_NAME' && value !== resolved.serviceName) conflictsWith = `programmatic serviceName='${resolved.serviceName}'`;
+    else if (key === 'OTEL_RESOURCE_ATTRIBUTES') conflictsWith = `programmatic serviceName='${resolved.serviceName}'`;
+    else if ((key === 'OTEL_EXPORTER_OTLP_ENDPOINT' || key === 'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT') && value !== resolved.tracesUrl) conflictsWith = `programmatic url='${resolved.tracesUrl}'`;
+    else if (key === 'OTEL_EXPORTER_OTLP_METRICS_ENDPOINT' && value !== resolved.metricsUrl) conflictsWith = `programmatic metricsUrl='${resolved.metricsUrl}'`;
+    else if ((key === 'OTEL_EXPORTER_OTLP_PROTOCOL' || key === 'OTEL_EXPORTER_OTLP_TRACES_PROTOCOL' || key === 'OTEL_EXPORTER_OTLP_METRICS_PROTOCOL') && value !== resolved.exporterProtocol) conflictsWith = `programmatic exporterProtocol='${resolved.exporterProtocol}'`;
+    else if (key === 'OTEL_TRACES_SAMPLER' || key === 'OTEL_TRACES_SAMPLER_ARG') conflictsWith = `programmatic samplingRatio=${resolved.samplingRatio}`;
+
+    if (conflictsWith) {
+      findings.push({key, value, conflictsWith});
+    }
+  }
+  return findings;
+}
 
 /**
 * Sets up tracing for the application using OpenTelemetry's NodeSDK.
@@ -146,9 +229,19 @@ export function setupTracing(options = {}) {
     diag.setLogger(new DiagConsoleLogger(), envLevel ?? DiagLogLevel.INFO);
   }
 
+  let resolvedTracesUrl = url;
+  let tracesUrlRewritten = false;
+  if (exporterProtocol === 'http/protobuf') {
+    const norm = normaliseOtlpHttpUrl(url, OTLP_HTTP_TRACES_PATH);
+    resolvedTracesUrl = norm.url;
+    tracesUrlRewritten = norm.rewritten;
+    if (norm.rewritten) {
+      console.info(`[@saidsef/tracing-node] http/protobuf traces url '${url}' rewritten to '${resolvedTracesUrl}' (signal path appended)`);
+    }
+  }
   const exportOptions = {
     concurrencyLimit,
-    url,
+    url: resolvedTracesUrl,
     timeoutMillis: 10000,
   };
   const TraceExporterCtor = exporterProtocol === 'http/protobuf' ? OTLPHttpProtoTraceExporter : OTLPGrpcTraceExporter;
@@ -167,10 +260,22 @@ export function setupTracing(options = {}) {
   });
 
   let metricReaders = [];
+  let resolvedMetricsUrl = null;
   if (enableMetrics) {
+    const rawMetricsUrl = metricsUrl || url;
+    resolvedMetricsUrl = rawMetricsUrl;
+    let metricsUrlRewritten = false;
+    if (exporterProtocol === 'http/protobuf') {
+      const norm = normaliseOtlpHttpUrl(rawMetricsUrl, OTLP_HTTP_METRICS_PATH);
+      resolvedMetricsUrl = norm.url;
+      metricsUrlRewritten = norm.rewritten;
+      if (metricsUrlRewritten) {
+        console.info(`[@saidsef/tracing-node] http/protobuf metrics url '${rawMetricsUrl}' rewritten to '${resolvedMetricsUrl}' (signal path appended)`);
+      }
+    }
     const MetricExporterCtor = exporterProtocol === 'http/protobuf' ? OTLPHttpProtoMetricExporter : OTLPGrpcMetricExporter;
     const metricExporter = new MetricExporterCtor({
-      url: metricsUrl || url,
+      url: resolvedMetricsUrl,
       concurrencyLimit,
       timeoutMillis: 10000,
     });
@@ -487,11 +592,30 @@ export function setupTracing(options = {}) {
     }));
   }
 
-  sdk = new NodeSDK({
+  const detectedResource = detectResources({
+    detectors: [envDetector, hostDetector, osDetector, processDetector, serviceInstanceIdDetector, containerDetector],
+  });
+  const mergedResource = detectedResource.merge(resource);
+
+  const envConflicts = detectConflictingOtelEnv({
     serviceName,
-    resource,
-    autoDetectResources: true,
-    resourceDetectors: [envDetector, hostDetector, osDetector, processDetector, serviceInstanceIdDetector, containerDetector],
+    tracesUrl: resolvedTracesUrl,
+    metricsUrl: resolvedMetricsUrl,
+    exporterProtocol,
+    samplingRatio,
+  });
+  for (const finding of envConflicts) {
+    console.warn(`[@saidsef/tracing-node] env ${finding.key}='${finding.value}' conflicts with ${finding.conflictsWith}; the SDK's NodeSDK resolution rules will decide which value is used.`);
+  }
+
+  const startupModeWarning = detectDegradedStartupMode();
+  if (startupModeWarning) {
+    console.warn(`[@saidsef/tracing-node] ${startupModeWarning}`);
+  }
+
+  sdk = new NodeSDK({
+    resource: mergedResource,
+    autoDetectResources: false,
     sampler: new ParentBasedSampler({
       root: new TraceIdRatioBasedSampler(samplingRatio),
     }),
@@ -513,6 +637,21 @@ export function setupTracing(options = {}) {
     process.once('SIGTERM', handler);
     process.once('SIGINT', handler);
   }
+
+  console.info(`[@saidsef/tracing-node] started ${JSON.stringify({
+    'service.name': serviceName,
+    'container.name': hostname,
+    'exporter.protocol': exporterProtocol,
+    'traces.url': resolvedTracesUrl,
+    'traces.url.rewritten': tracesUrlRewritten,
+    'metrics.enabled': enableMetrics,
+    'metrics.url': resolvedMetricsUrl,
+    'sampling.ratio': samplingRatio,
+    'install_signal_handlers': installSignalHandlers,
+    'instrumentations': instrumentations.map((i) => i.constructor.name),
+    'otel_env_overrides': envConflicts.map((f) => f.key),
+    'startup_mode_degraded': startupModeWarning != null,
+  })}`);
 
   return trace.getTracer(serviceName);
 }

--- a/libs/index.test.mjs
+++ b/libs/index.test.mjs
@@ -1,6 +1,7 @@
 // index.test.mjs
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
+import { metrics, trace } from '@opentelemetry/api';
 
 describe('setupTracing', () => {
   let stopTracing;
@@ -69,5 +70,202 @@ describe('setupTracing', () => {
       enableDnsInstrumentation: true,
     });
     assert.ok(tracer, 'tracer should be defined');
+  });
+
+  it('should accept samplingRatio option', async () => {
+    const { setupTracing } = await import('./index.mjs');
+    const tracer = setupTracing({
+      serviceName: 'test-service',
+      url: 'http://localhost:4317',
+      samplingRatio: 0.1,
+    });
+    assert.ok(tracer, 'tracer should be defined');
+  });
+
+  it('should throw on invalid samplingRatio', async () => {
+    const { setupTracing } = await import('./index.mjs');
+    assert.throws(() => {
+      setupTracing({
+        serviceName: 'test-service',
+        url: 'http://localhost:4317',
+        samplingRatio: 1.5,
+      });
+    }, /samplingRatio must be a number between 0 and 1/);
+  });
+
+  it('should accept http/protobuf exporter protocol', async () => {
+    const { setupTracing } = await import('./index.mjs');
+    const tracer = setupTracing({
+      serviceName: 'test-service',
+      url: 'http://localhost:4318/v1/traces',
+      exporterProtocol: 'http/protobuf',
+    });
+    assert.ok(tracer, 'tracer should be defined');
+  });
+
+  it('should throw on invalid exporterProtocol', async () => {
+    const { setupTracing } = await import('./index.mjs');
+    assert.throws(() => {
+      setupTracing({
+        serviceName: 'test-service',
+        url: 'http://localhost:4317',
+        exporterProtocol: 'thrift',
+      });
+    }, /exporterProtocol must be 'grpc' or 'http\/protobuf'/);
+  });
+
+  it('should accept enableMetrics: false and skip MeterProvider', async () => {
+    const { setupTracing } = await import('./index.mjs');
+    const tracer = setupTracing({
+      serviceName: 'test-service',
+      url: 'http://localhost:4317',
+      enableMetrics: false,
+    });
+    assert.ok(tracer, 'tracer should be defined');
+  });
+
+  it('should register a global MeterProvider by default (not NoOp)', async () => {
+    const { setupTracing } = await import('./index.mjs');
+    setupTracing({
+      serviceName: 'test-service',
+      url: 'http://localhost:4317',
+    });
+    const provider = metrics.getMeterProvider();
+    assert.ok(provider, 'a global meter provider should be set');
+    assert.notStrictEqual(
+      provider.constructor.name,
+      'NoopMeterProvider',
+      'global provider should be the SDK MeterProvider, not the NoOp fallback'
+    );
+    assert.strictEqual(
+      provider.constructor.name,
+      'MeterProvider',
+      'global provider should be @opentelemetry/sdk-metrics MeterProvider'
+    );
+  });
+
+  it('should release the global MeterProvider after stopTracing so a subsequent setupTracing can re-register', async () => {
+    const { setupTracing } = await import('./index.mjs');
+    setupTracing({
+      serviceName: 'svc-1',
+      url: 'http://localhost:4317',
+    });
+    const first = metrics.getMeterProvider();
+    assert.strictEqual(first.constructor.name, 'MeterProvider');
+    await stopTracing();
+    assert.strictEqual(
+      metrics.getMeterProvider().constructor.name,
+      'NoopMeterProvider',
+      'after stopTracing the global should be released back to NoOp'
+    );
+    setupTracing({
+      serviceName: 'svc-2',
+      url: 'http://localhost:4317',
+    });
+    const second = metrics.getMeterProvider();
+    assert.strictEqual(second.constructor.name, 'MeterProvider', 'a fresh setupTracing should register a new global MeterProvider');
+    assert.notStrictEqual(first, second, 'second provider instance should be distinct from the first');
+  });
+
+  it('should accept metricsUrl override', async () => {
+    const { setupTracing } = await import('./index.mjs');
+    const tracer = setupTracing({
+      serviceName: 'test-service',
+      url: 'http://localhost:4317',
+      metricsUrl: 'http://localhost:14317',
+    });
+    assert.ok(tracer, 'tracer should be defined');
+  });
+
+  it('should skip pg instrumentation when explicitly disabled', async () => {
+    const { setupTracing } = await import('./index.mjs');
+    const tracer = setupTracing({
+      serviceName: 'test-service',
+      url: 'http://localhost:4317',
+      enablePgInstrumentation: false,
+    });
+    assert.ok(tracer, 'tracer should be defined');
+  });
+
+  it('should not crash when auto-detect targets are not installed', async () => {
+    const { setupTracing } = await import('./index.mjs');
+    const tracer = setupTracing({
+      serviceName: 'test-service',
+      url: 'http://localhost:4317',
+    });
+    assert.ok(tracer, 'tracer should be defined despite pg/mongodb/kafkajs/amqplib/grpc being absent');
+  });
+
+  it('should bootstrap via @opentelemetry/sdk-node so tracer.startSpan produces recording spans', async () => {
+    const { setupTracing } = await import('./index.mjs');
+    setupTracing({
+      serviceName: 'test-service',
+      url: 'http://localhost:4317',
+    });
+    const tracer = trace.getTracer('test');
+    const span = tracer.startSpan('check');
+    assert.strictEqual(span.isRecording(), true, 'with NodeSDK wired and sampler at 1.0, spans must be recording');
+    span.end();
+  });
+
+  it('should release the global tracer provider after stopTracing so subsequent tracers are NoOp until re-init', async () => {
+    const { setupTracing } = await import('./index.mjs');
+    setupTracing({
+      serviceName: 'svc-1',
+      url: 'http://localhost:4317',
+    });
+    const recordingSpan = trace.getTracer('t').startSpan('first');
+    assert.strictEqual(recordingSpan.isRecording(), true);
+    recordingSpan.end();
+
+    await stopTracing();
+
+    const noopSpan = trace.getTracer('t').startSpan('after-shutdown');
+    assert.strictEqual(noopSpan.isRecording(), false, 'after stopTracing, the global proxy must have no delegate so spans are non-recording');
+    noopSpan.end();
+
+    setupTracing({
+      serviceName: 'svc-2',
+      url: 'http://localhost:4317',
+    });
+    const reinitSpan = trace.getTracer('t').startSpan('second');
+    assert.strictEqual(reinitSpan.isRecording(), true, 'a fresh setupTracing must produce recording spans again');
+    reinitSpan.end();
+  });
+
+  it('should respect enableMetrics: false even when OTEL_METRICS_EXPORTER is set in env', async () => {
+    process.env.OTEL_METRICS_EXPORTER = 'otlp';
+    try {
+      const { setupTracing } = await import('./index.mjs');
+      setupTracing({
+        serviceName: 'test-service',
+        url: 'http://localhost:4317',
+        enableMetrics: false,
+      });
+      assert.strictEqual(
+        metrics.getMeterProvider().constructor.name,
+        'NoopMeterProvider',
+        'enableMetrics: false must not be overridden by OTEL_METRICS_EXPORTER env'
+      );
+    } finally {
+      delete process.env.OTEL_METRICS_EXPORTER;
+    }
+  });
+
+  it('should register and clean up signal handlers when requested', async () => {
+    const { setupTracing } = await import('./index.mjs');
+    const beforeSigterm = process.listenerCount('SIGTERM');
+    const beforeSigint = process.listenerCount('SIGINT');
+    const tracer = setupTracing({
+      serviceName: 'test-service',
+      url: 'http://localhost:4317',
+      installSignalHandlers: true,
+    });
+    assert.ok(tracer, 'tracer should be defined');
+    assert.strictEqual(process.listenerCount('SIGTERM'), beforeSigterm + 1, 'SIGTERM listener should be added');
+    assert.strictEqual(process.listenerCount('SIGINT'), beforeSigint + 1, 'SIGINT listener should be added');
+    await stopTracing();
+    assert.strictEqual(process.listenerCount('SIGTERM'), beforeSigterm, 'SIGTERM listener should be removed');
+    assert.strictEqual(process.listenerCount('SIGINT'), beforeSigint, 'SIGINT listener should be removed');
   });
 });

--- a/libs/index.test.mjs
+++ b/libs/index.test.mjs
@@ -12,6 +12,17 @@ describe('setupTracing', () => {
     delete process.env.ENDPOINT;
     delete process.env.HOSTNAME;
     delete process.env.CONTAINER_NAME;
+    delete process.env.OTEL_SDK_DISABLED;
+    delete process.env.OTEL_SERVICE_NAME;
+    delete process.env.OTEL_RESOURCE_ATTRIBUTES;
+    delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+    delete process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT;
+    delete process.env.OTEL_EXPORTER_OTLP_PROTOCOL;
+    delete process.env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL;
+    delete process.env.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL;
+    delete process.env.OTEL_TRACES_SAMPLER;
+    delete process.env.OTEL_TRACES_SAMPLER_ARG;
 
     // Import and store stopTracing for cleanup
     const tracing = await import('./index.mjs');
@@ -249,6 +260,135 @@ describe('setupTracing', () => {
       );
     } finally {
       delete process.env.OTEL_METRICS_EXPORTER;
+    }
+  });
+
+  it('should append /v1/traces and /v1/metrics to a bare base URL when exporterProtocol is http/protobuf', async () => {
+    const { setupTracing } = await import('./index.mjs');
+    const infoLines = [];
+    const origInfo = console.info;
+    console.info = (msg) => infoLines.push(String(msg));
+    try {
+      setupTracing({
+        serviceName: 'test-service',
+        url: 'http://localhost:4318',
+        exporterProtocol: 'http/protobuf',
+      });
+    } finally {
+      console.info = origInfo;
+    }
+    const tracesRewrite = infoLines.find((l) => l.includes("traces url 'http://localhost:4318'") && l.includes('http://localhost:4318/v1/traces'));
+    const metricsRewrite = infoLines.find((l) => l.includes("metrics url 'http://localhost:4318'") && l.includes('http://localhost:4318/v1/metrics'));
+    assert.ok(tracesRewrite, 'expected an info line announcing the trace url rewrite');
+    assert.ok(metricsRewrite, 'expected an info line announcing the metrics url rewrite');
+    const banner = infoLines.find((l) => l.includes('[@saidsef/tracing-node] started'));
+    assert.ok(banner, 'expected the startup banner');
+    assert.ok(banner.includes('"traces.url":"http://localhost:4318/v1/traces"'), 'banner must show the rewritten traces url');
+    assert.ok(banner.includes('"metrics.url":"http://localhost:4318/v1/metrics"'), 'banner must show the rewritten metrics url');
+    assert.ok(banner.includes('"traces.url.rewritten":true'), 'banner must flag that the trace url was rewritten');
+  });
+
+  it('should leave http/protobuf URLs untouched when the signal path is already present', async () => {
+    const { setupTracing } = await import('./index.mjs');
+    const infoLines = [];
+    const origInfo = console.info;
+    console.info = (msg) => infoLines.push(String(msg));
+    try {
+      setupTracing({
+        serviceName: 'test-service',
+        url: 'http://localhost:4318/v1/traces',
+        metricsUrl: 'http://localhost:4318/v1/metrics',
+        exporterProtocol: 'http/protobuf',
+      });
+    } finally {
+      console.info = origInfo;
+    }
+    const anyRewrite = infoLines.find((l) => l.includes('rewritten to'));
+    assert.strictEqual(anyRewrite, undefined, 'no rewrite should happen when the path is already correct');
+    const banner = infoLines.find((l) => l.includes('[@saidsef/tracing-node] started'));
+    assert.ok(banner.includes('"traces.url.rewritten":false'));
+  });
+
+  it('should warn and prefer programmatic serviceName when OTEL_SERVICE_NAME is set in env', async () => {
+    process.env.OTEL_SERVICE_NAME = 'hijacked-by-env';
+    const warnings = [];
+    const origWarn = console.warn;
+    console.warn = (msg) => warnings.push(String(msg));
+    try {
+      const { setupTracing } = await import('./index.mjs');
+      setupTracing({
+        serviceName: 'programmatic-wins',
+        url: 'http://localhost:4317',
+      });
+      const conflictWarning = warnings.find((w) =>
+        w.includes("OTEL_SERVICE_NAME='hijacked-by-env'") &&
+        w.includes("programmatic serviceName='programmatic-wins'")
+      );
+      assert.ok(conflictWarning, `expected a console.warn about OTEL_SERVICE_NAME conflict, got: ${warnings.join('\n')}`);
+    } finally {
+      console.warn = origWarn;
+      delete process.env.OTEL_SERVICE_NAME;
+    }
+  });
+
+  it('should emit a single startup banner line containing the resolved service.name and trace url', async () => {
+    const { setupTracing } = await import('./index.mjs');
+    const infoLines = [];
+    const origInfo = console.info;
+    console.info = (msg) => infoLines.push(String(msg));
+    try {
+      setupTracing({
+        serviceName: 'banner-svc',
+        url: 'http://localhost:4317',
+      });
+    } finally {
+      console.info = origInfo;
+    }
+    const banners = infoLines.filter((l) => l.includes('[@saidsef/tracing-node] started'));
+    assert.strictEqual(banners.length, 1, 'exactly one startup banner per setupTracing call');
+    assert.ok(banners[0].includes('"service.name":"banner-svc"'));
+    assert.ok(banners[0].includes('"traces.url":"http://localhost:4317"'));
+    assert.ok(banners[0].includes('"otel_env_overrides":[]'));
+    assert.ok(banners[0].includes('"exporter.protocol":"grpc"'));
+  });
+
+  it('should warn when started via --require without --import (ESM consumers should use --import)', async () => {
+    const originalExecArgv = process.execArgv;
+    process.execArgv = [...originalExecArgv.filter((a) => !a.includes('--require') && !a.includes('--import')), '--require', './bootstrap.mjs'];
+    const warnings = [];
+    const origWarn = console.warn;
+    console.warn = (msg) => warnings.push(String(msg));
+    try {
+      const { setupTracing } = await import('./index.mjs');
+      setupTracing({
+        serviceName: 'test-service',
+        url: 'http://localhost:4317',
+      });
+      const warn = warnings.find((w) => w.includes('startup uses --require but not --import'));
+      assert.ok(warn, `expected a console.warn about degraded startup mode, got: ${warnings.join('\n')}`);
+    } finally {
+      console.warn = origWarn;
+      process.execArgv = originalExecArgv;
+    }
+  });
+
+  it('should NOT warn about startup mode when --import is used', async () => {
+    const originalExecArgv = process.execArgv;
+    process.execArgv = [...originalExecArgv.filter((a) => !a.includes('--require') && !a.includes('--import')), '--import', './bootstrap.mjs'];
+    const warnings = [];
+    const origWarn = console.warn;
+    console.warn = (msg) => warnings.push(String(msg));
+    try {
+      const { setupTracing } = await import('./index.mjs');
+      setupTracing({
+        serviceName: 'test-service',
+        url: 'http://localhost:4317',
+      });
+      const warn = warnings.find((w) => w.includes('startup uses --require'));
+      assert.strictEqual(warn, undefined, '--import should not trigger the startup-mode warning');
+    } finally {
+      console.warn = origWarn;
+      process.execArgv = originalExecArgv;
     }
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,31 +1,42 @@
 {
   "name": "@saidsef/tracing-node",
-  "version": "3.21.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@saidsef/tracing-node",
-      "version": "3.21.0",
+      "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "^2.8.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "^0.219.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "^0.219.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.219.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.219.0",
         "@opentelemetry/instrumentation": "^0.219.0",
+        "@opentelemetry/instrumentation-amqplib": "^0.66.0",
         "@opentelemetry/instrumentation-aws-sdk": "^0.74.0",
-        "@opentelemetry/instrumentation-connect": "^0.62.0",
         "@opentelemetry/instrumentation-dns": "^0.62.0",
         "@opentelemetry/instrumentation-express": "^0.67.0",
         "@opentelemetry/instrumentation-fs": "^0.38.0",
+        "@opentelemetry/instrumentation-grpc": "^0.219.0",
         "@opentelemetry/instrumentation-http": "^0.219.0",
         "@opentelemetry/instrumentation-ioredis": "^0.67.0",
+        "@opentelemetry/instrumentation-kafkajs": "^0.28.0",
+        "@opentelemetry/instrumentation-mongodb": "^0.72.0",
+        "@opentelemetry/instrumentation-pg": "^0.71.0",
         "@opentelemetry/instrumentation-pino": "^0.65.0",
+        "@opentelemetry/instrumentation-runtime-node": "^0.32.0",
+        "@opentelemetry/instrumentation-undici": "^0.29.0",
+        "@opentelemetry/resource-detector-container": "^0.8.10",
         "@opentelemetry/resources": "^2.8.0",
+        "@opentelemetry/sdk-metrics": "^2.8.0",
+        "@opentelemetry/sdk-node": "^0.219.0",
         "@opentelemetry/sdk-trace-base": "^2.8.0",
         "@opentelemetry/sdk-trace-node": "^2.8.0",
-        "@opentelemetry/semantic-conventions": "^1.41.1",
-        "opentelemetry-instrumentation-elasticsearch": "0.41.0"
+        "@opentelemetry/semantic-conventions": "^1.41.1"
       },
       "devDependencies": {
         "eslint": "^10.5.0",
@@ -1291,6 +1302,22 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@opentelemetry/configuration": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/configuration/-/configuration-0.219.0.tgz",
+      "integrity": "sha512-wXZUYv4ngu43nA4WEhuXNacm46LW+17LRM8nKyIhBzroRA24PBYjMnakwzR/w777nFUB5xlgsYTTeuXxumZM1Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "yaml": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.8.0.tgz",
@@ -1318,6 +1345,145 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.219.0.tgz",
+      "integrity": "sha512-7SvzDCIclHWAcCwZ1MTOLcwn4BVNPGI3QxS/DJraPNe1TTL+4TvUBq5zeQV8tsnYvtDN7wKW2qocVmaCP2l7sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/otlp-exporter-base": "0.219.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.219.0",
+        "@opentelemetry/otlp-transformer": "0.219.0",
+        "@opentelemetry/sdk-logs": "0.219.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.219.0.tgz",
+      "integrity": "sha512-mhl2HL6GmZI8b8PwPfqMws/5ovJfbRTxwc9Y5agVVHiQ+e5SL1btsFr/kJDgt7YCexDtsUn5HAreHQO9szFS0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.219.0",
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/otlp-exporter-base": "0.219.0",
+        "@opentelemetry/otlp-transformer": "0.219.0",
+        "@opentelemetry/sdk-logs": "0.219.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.219.0.tgz",
+      "integrity": "sha512-Ayw4Gf71PS9jhBVaYywa4WsajnqfDehMkTdVH3TSAVHqPcsAv/AhH/wTNRYNt99szeYr6Gbd/D6RjZD77wAxHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.219.0",
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/otlp-exporter-base": "0.219.0",
+        "@opentelemetry/otlp-transformer": "0.219.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/sdk-logs": "0.219.0",
+        "@opentelemetry/sdk-trace-base": "2.8.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.219.0.tgz",
+      "integrity": "sha512-6LaaSrPxK5L55bXevWajvOMxGOpNm0n12tG53TeZaUeNzXwLPg6d2KCC1zAlGsojan+xRG71mA4Qqs9K2VVrKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.219.0",
+        "@opentelemetry/otlp-exporter-base": "0.219.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.219.0",
+        "@opentelemetry/otlp-transformer": "0.219.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/sdk-metrics": "2.8.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.219.0.tgz",
+      "integrity": "sha512-6CaDRbMVHZSDWzNXwrR8y/H4B/Z1eMNnkHiPQlTx3Ojz2OHY4X/aff/UC4P/3pHUQSuTfi3oh2UsPPZppw+Vrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/otlp-exporter-base": "0.219.0",
+        "@opentelemetry/otlp-transformer": "0.219.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/sdk-metrics": "2.8.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.219.0.tgz",
+      "integrity": "sha512-DUS7XyIiEnoeccQUvuKy0G2/YqeKhpN8FVIrGbrLNIVMj10yeIFLRzRv0tibCI2kXXvlTTABVexGAk78wHk2ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.219.0",
+        "@opentelemetry/otlp-exporter-base": "0.219.0",
+        "@opentelemetry/otlp-transformer": "0.219.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/sdk-metrics": "2.8.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-prometheus": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.219.0.tgz",
+      "integrity": "sha512-TxOnJ85eWJY5JyOJsNMXiRTYlkDcOv0u3KbXEzWCc+tUS9sjL/BC6BcdxZ0B9r2OFVqsrZFXUzSD2sZUy42Ucw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/sdk-metrics": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
       "version": "0.219.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.219.0.tgz",
@@ -1339,6 +1505,62 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.219.0.tgz",
+      "integrity": "sha512-9t6SvBXXBEjOBcIzgozvBbd3jWrv3Gt3ngGhl1fhdZ/zRc7oZDVOFEqbi2zlBpW9BXhgDMKv422J0DL/3iQWfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/otlp-exporter-base": "0.219.0",
+        "@opentelemetry/otlp-transformer": "0.219.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/sdk-trace-base": "2.8.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.219.0.tgz",
+      "integrity": "sha512-lF/LUBfhOFmxJa+SQsLN7ziV4MHa2pyKgOM6JNehSOfU+npjM4gwm9oIKEJrzrWcexMcqydiyoFy0XCb1Ql3wQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/otlp-exporter-base": "0.219.0",
+        "@opentelemetry/otlp-transformer": "0.219.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/sdk-trace-base": "2.8.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.8.0.tgz",
+      "integrity": "sha512-Mj84UkEa17BK2o903VTXW3wM8CrSZexGs4tRGVZVIMM9ni1T6TuGx5IrRfoWKAbshx42D5/kc7YV+axypLPYyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/sdk-trace-base": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation": {
       "version": "0.219.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.219.0.tgz",
@@ -1356,6 +1578,23 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation-amqplib": {
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.66.0.tgz",
+      "integrity": "sha512-lyJgobzP0Ce+tRGOkdnrb60apfqU89xB9FeMTmo1TJU007KTMLiLFd4iCfTiBEXzBsVplx7kwrVN4FqGBUcD2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.219.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation-aws-sdk": {
       "version": "0.74.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.74.0.tgz",
@@ -1365,24 +1604,6 @@
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/instrumentation": "^0.219.0",
         "@opentelemetry/semantic-conventions": "^1.34.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-connect": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.62.0.tgz",
-      "integrity": "sha512-ZGV2sOyeffqMiqoh4RpsPTs/TUI5cCS+cEWvC9wUfvaEekR5omR6P/ClG+QDwasGBlKx2zfFPjSYPpzUo81XAw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.219.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
-        "@types/connect": "3.4.38"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1439,6 +1660,22 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation-grpc": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.219.0.tgz",
+      "integrity": "sha512-GyW1Kfbf7uiJXeBZovB/uXPUdkaZYWzB2ZPCdY2CU7+6V207u8wlCM+zVd3UwhEjOBrMbZAGq+m38aBEI/EVtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "0.219.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation-http": {
       "version": "0.219.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.219.0.tgz",
@@ -1474,6 +1711,58 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation-kafkajs": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.28.0.tgz",
+      "integrity": "sha512-dztkg70nJds3Uc0Xo3NFlRqL5iYgGYWh8myuuGfRC6NnXJchY0Kw9QnBjTZxBSldXU+P6nv2snDVMmlxuy6fEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.219.0",
+        "@opentelemetry/semantic-conventions": "^1.30.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongodb": {
+      "version": "0.72.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.72.0.tgz",
+      "integrity": "sha512-WYgGzvlHzdoxHlrhysYtjxE4RC23j/iFZ66hdMJuAoczOWoD/xb6LhRwaz4CM+LKyKtcSIadAjSUyGv2B+SNwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.219.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg": {
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.71.0.tgz",
+      "integrity": "sha512-jAhfyZeOkEKh3cQ5nm1tNWqHg7HFARyAe+p4BSoDHnB79c1woyEvDKqS11Hj/DjtceP+vrurIfcDs7Fqiy11mQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.219.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
+        "@opentelemetry/sql-common": "^0.42.0",
+        "@types/pg": "8.15.6",
+        "@types/pg-pool": "2.0.7"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation-pino": {
       "version": "0.65.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.65.0.tgz",
@@ -1489,6 +1778,40 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-runtime-node": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-runtime-node/-/instrumentation-runtime-node-0.32.0.tgz",
+      "integrity": "sha512-Jo1jSgrHlah3lPpGNPsIpF0q52D5uSLRJrztWUoPc1/Tli2ZWZ+cArgNtcdmiLuKhW21MwYbbcrNw1fbOPeR3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "^0.219.0",
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.219.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-undici": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.29.0.tgz",
+      "integrity": "sha512-SnA+0XgGc595jtnwFVfWy7Vgfr5hle4D5YKIlm0U4z8aK9YoCZVUn1xAkVZ2evaJyykiDF50FBzr1XZ0uj8CPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.219.0",
+        "@opentelemetry/semantic-conventions": "^1.24.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
@@ -1545,6 +1868,36 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/propagator-b3": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.8.0.tgz",
+      "integrity": "sha512-SazlvuSKi5533rPHTW2TwBwdMakhjZST4SYs0YauuvfGDkT13KbG1gJS75hV0uWVeevhtVP9sAIlaZLTHdSbMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.8.0.tgz",
+      "integrity": "sha512-Xnz9zZvvQzUw+9DrOn0MomR7BxFCkA2pcfXBQuHC28ndJpSbjLs7knzYb05kw5SyCjSsEWombkZMgGcJSk8JVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/redis-common": {
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.3.tgz",
@@ -1552,6 +1905,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
+      }
+    },
+    "node_modules/@opentelemetry/resource-detector-container": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.8.10.tgz",
+      "integrity": "sha512-aMU2wG4ktcqy6zEotdbIkkX5ACKRxEZLX1ZlMH0dea0M2+2KfabJc1lHPqAIFaa+CD37fCION55e69QmYwqX4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/resources": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
       }
     },
     "node_modules/@opentelemetry/resources": {
@@ -1604,6 +1973,46 @@
         "@opentelemetry/api": ">=1.9.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/sdk-node": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.219.0.tgz",
+      "integrity": "sha512-NWLpWLEb8gV3+JBHYoIrktbM385wyHpRJoh3J/4Q52d4PR+AlPMNGJT3DzBUrDSUEVbKAXoHR+EDAPxtiNcj8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.219.0",
+        "@opentelemetry/configuration": "0.219.0",
+        "@opentelemetry/context-async-hooks": "2.8.0",
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.219.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.219.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.219.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.219.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.219.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.219.0",
+        "@opentelemetry/exporter-prometheus": "0.219.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.219.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.219.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.219.0",
+        "@opentelemetry/exporter-zipkin": "2.8.0",
+        "@opentelemetry/instrumentation": "0.219.0",
+        "@opentelemetry/otlp-exporter-base": "0.219.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.219.0",
+        "@opentelemetry/propagator-b3": "2.8.0",
+        "@opentelemetry/propagator-jaeger": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/sdk-logs": "0.219.0",
+        "@opentelemetry/sdk-metrics": "2.8.0",
+        "@opentelemetry/sdk-trace-base": "2.8.0",
+        "@opentelemetry/sdk-trace-node": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
@@ -1645,6 +2054,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sql-common": {
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.42.0.tgz",
+      "integrity": "sha512-nwUwUU+8O8a4bnLqk6CodWeegGMEANgC94KTAhXcpGWLrW/2/hek/0ajNbjXnSOoNuCX+nteUPs46HFHhou9Xw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1811,15 +2235,6 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -1877,11 +2292,25 @@
         "undici-types": "~7.18.0"
       }
     },
-    "node_modules/@types/shimmer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
-      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
-      "license": "MIT"
+    "node_modules/@types/pg": {
+      "version": "8.15.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
+      "integrity": "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pg-pool": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.7.tgz",
+      "integrity": "sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pg": "*"
+      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -3229,15 +3658,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3365,18 +3785,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3474,21 +3882,6 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -4579,120 +4972,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/opentelemetry-instrumentation-elasticsearch": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-elasticsearch/-/opentelemetry-instrumentation-elasticsearch-0.41.0.tgz",
-      "integrity": "sha512-zNZSbz4qnV+RogsJ2xm9wRlRw02Nm9okg8INxdlis6+LAI89eCEoEZQ5eA0iJzGzNffMQaC8oaT1ka2LxF5+mQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^1.24.1",
-        "@opentelemetry/instrumentation": "^0.51.1",
-        "@opentelemetry/semantic-conventions": "^1.24.1"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.8.0"
-      }
-    },
-    "node_modules/opentelemetry-instrumentation-elasticsearch/node_modules/@opentelemetry/api-logs": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.1.tgz",
-      "integrity": "sha512-E3skn949Pk1z2XtXu/lxf6QAZpawuTM/IUEXcAzpiUkTd73Hmvw26FiN3cJuTmkpM5hZzHwkomVdtrh/n/zzwA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/opentelemetry-instrumentation-elasticsearch/node_modules/@opentelemetry/core": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/opentelemetry-instrumentation-elasticsearch/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.51.1.tgz",
-      "integrity": "sha512-JIrvhpgqY6437QIqToyozrUG1h5UhwHkaGK/WAX+fkrpyPtc+RO5FkRtUd9BH0MibabHHvqsnBGKfKVijbmp8w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.51.1",
-        "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.7.4",
-        "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/opentelemetry-instrumentation-elasticsearch/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/opentelemetry-instrumentation-elasticsearch/node_modules/cjs-module-lexer": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
-      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
-      "license": "MIT"
-    },
-    "node_modules/opentelemetry-instrumentation-elasticsearch/node_modules/import-in-the-middle": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.4.tgz",
-      "integrity": "sha512-Lk+qzWmiQuRPPulGQeK5qq0v32k2bHnWrRPFgqyvhw7Kkov5L6MOLOIU3pcWeujc9W4q54Cp3Q2WV16eQkc7Bg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "acorn": "^8.8.2",
-        "acorn-import-attributes": "^1.9.5",
-        "cjs-module-lexer": "^1.2.2",
-        "module-details-from-path": "^1.0.3"
-      }
-    },
-    "node_modules/opentelemetry-instrumentation-elasticsearch/node_modules/require-in-the-middle": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
-      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.5",
-        "module-details-from-path": "^1.0.3",
-        "resolve": "^1.22.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/opentelemetry-instrumentation-elasticsearch/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4809,12 +5088,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "license": "MIT"
-    },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -4838,6 +5111,37 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4936,6 +5240,45 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -5065,26 +5408,6 @@
         "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
-    "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -5140,12 +5463,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
@@ -5406,18 +5723,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/synckit": {
@@ -5804,6 +6109,15 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -5819,6 +6133,21 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saidsef/tracing-node",
-  "version": "3.21.0",
+  "version": "4.0.0",
   "description": "tracing NodeJS - Wrapper for OpenTelemetry instrumentation packages",
   "main": "libs/index.mjs",
   "scripts": {
@@ -32,21 +32,32 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/context-async-hooks": "^2.8.0",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "^0.219.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "^0.219.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.219.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.219.0",
     "@opentelemetry/instrumentation": "^0.219.0",
+    "@opentelemetry/instrumentation-amqplib": "^0.66.0",
     "@opentelemetry/instrumentation-aws-sdk": "^0.74.0",
-    "@opentelemetry/instrumentation-connect": "^0.62.0",
     "@opentelemetry/instrumentation-dns": "^0.62.0",
     "@opentelemetry/instrumentation-express": "^0.67.0",
     "@opentelemetry/instrumentation-fs": "^0.38.0",
+    "@opentelemetry/instrumentation-grpc": "^0.219.0",
     "@opentelemetry/instrumentation-http": "^0.219.0",
     "@opentelemetry/instrumentation-ioredis": "^0.67.0",
+    "@opentelemetry/instrumentation-kafkajs": "^0.28.0",
+    "@opentelemetry/instrumentation-mongodb": "^0.72.0",
+    "@opentelemetry/instrumentation-pg": "^0.71.0",
     "@opentelemetry/instrumentation-pino": "^0.65.0",
+    "@opentelemetry/instrumentation-runtime-node": "^0.32.0",
+    "@opentelemetry/instrumentation-undici": "^0.29.0",
+    "@opentelemetry/resource-detector-container": "^0.8.10",
     "@opentelemetry/resources": "^2.8.0",
+    "@opentelemetry/sdk-metrics": "^2.8.0",
+    "@opentelemetry/sdk-node": "^0.219.0",
     "@opentelemetry/sdk-trace-base": "^2.8.0",
     "@opentelemetry/sdk-trace-node": "^2.8.0",
-    "@opentelemetry/semantic-conventions": "^1.41.1",
-    "opentelemetry-instrumentation-elasticsearch": "0.41.0"
+    "@opentelemetry/semantic-conventions": "^1.41.1"
   },
   "devDependencies": {
     "eslint": "^10.5.0",

--- a/test/alloy-tempo-smoke/alloy/config.alloy
+++ b/test/alloy-tempo-smoke/alloy/config.alloy
@@ -1,0 +1,24 @@
+otelcol.receiver.otlp "default" {
+  grpc {
+    endpoint = "0.0.0.0:4317"
+  }
+  http {
+    endpoint = "0.0.0.0:4318"
+  }
+
+  output {
+    traces  = [otelcol.exporter.otlp.tempo.input]
+    metrics = []
+    logs    = []
+  }
+}
+
+otelcol.exporter.otlp "tempo" {
+  client {
+    endpoint = "tempo:4317"
+    tls {
+      insecure             = true
+      insecure_skip_verify = true
+    }
+  }
+}

--- a/test/alloy-tempo-smoke/docker-compose.yml
+++ b/test/alloy-tempo-smoke/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  tempo:
+    image: docker.io/grafana/tempo:2.10.3
+    command: ["-config.file=/etc/tempo/tempo.yml"]
+    volumes:
+      - ./tempo/tempo.yml:/etc/tempo/tempo.yml:ro
+    ports:
+      - "3200:3200"
+    networks: [otel]
+
+  alloy:
+    image: docker.io/grafana/alloy:v1.16.2
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - --storage.path=/var/lib/alloy/data
+      - /etc/alloy/config.alloy
+    volumes:
+      - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+      - "12345:12345"
+    depends_on:
+      - tempo
+    networks: [otel]
+
+networks:
+  otel: {}

--- a/test/alloy-tempo-smoke/smoke.mjs
+++ b/test/alloy-tempo-smoke/smoke.mjs
@@ -1,0 +1,96 @@
+import {trace, SpanKind} from '@opentelemetry/api';
+import {setupTracing, stopTracing} from '../../libs/index.mjs';
+
+const TEMPO_API = 'http://localhost:3200';
+
+async function waitForTempoReady(maxSeconds = 30) {
+  for (let i = 0; i < maxSeconds; i++) {
+    try {
+      const r = await fetch(`${TEMPO_API}/ready`);
+      if (r.ok) return;
+    } catch {}
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error('Tempo /ready never returned 200');
+}
+
+async function searchTempo(serviceName, maxSeconds = 30) {
+  const url = `${TEMPO_API}/api/search?tags=${encodeURIComponent(`service.name=${serviceName}`)}&limit=20`;
+  for (let i = 0; i < maxSeconds; i++) {
+    const r = await fetch(url);
+    if (r.ok) {
+      const body = await r.json();
+      if (body.traces && body.traces.length > 0) return body.traces;
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  return [];
+}
+
+async function emitWorkload(label, opts) {
+  await stopTracing().catch(() => {});
+  const tracer = setupTracing(opts);
+  const root = tracer.startSpan(`${label}-root`, {kind: SpanKind.SERVER});
+  root.setAttribute('test.label', label);
+  const child = tracer.startSpan(`${label}-child`, {kind: SpanKind.CLIENT});
+  child.setAttribute('peer.service', 'fake-downstream');
+  child.end();
+  root.end();
+  await stopTracing();
+}
+
+async function main() {
+  console.log('# Wait for Tempo readiness');
+  await waitForTempoReady();
+
+  console.log('# Phase 1: grpc default (matches saidsef bootstrap)');
+  await emitWorkload('grpc', {
+    serviceName: 'saidsef',
+    containerName: process.env.HOSTNAME,
+    url: 'http://localhost:4317',
+    enableDnsInstrumentation: false,
+  });
+
+  console.log('# Phase 2: http/protobuf with BARE URL (would have failed pre-fix; new code auto-appends /v1/traces)');
+  await emitWorkload('httpproto-bare', {
+    serviceName: 'saidsef-httpproto-bare',
+    url: 'http://localhost:4318',
+    exporterProtocol: 'http/protobuf',
+    enableMetrics: false,
+  });
+
+  console.log('# Phase 3: env conflict: OTEL_SERVICE_NAME set, programmatic must win');
+  process.env.OTEL_SERVICE_NAME = 'hijacked-by-env';
+  try {
+    await emitWorkload('envconflict', {
+      serviceName: 'saidsef-programmatic-wins',
+      url: 'http://localhost:4317',
+    });
+  } finally {
+    delete process.env.OTEL_SERVICE_NAME;
+  }
+
+  console.log('# Wait for Tempo to ingest...');
+  await new Promise((r) => setTimeout(r, 6000));
+
+  let exitCode = 0;
+  for (const svc of ['saidsef', 'saidsef-httpproto-bare', 'saidsef-programmatic-wins']) {
+    const traces = await searchTempo(svc);
+    if (traces.length === 0) {
+      console.error(`FAIL: no traces found for service.name=${svc}`);
+      exitCode = 1;
+    } else {
+      console.log(`OK:   ${traces.length} trace(s) found for service.name=${svc} (first traceID=${traces[0].traceID})`);
+    }
+  }
+  const hijacked = await searchTempo('hijacked-by-env', 3);
+  if (hijacked.length > 0) {
+    console.error(`FAIL: traces leaked under service.name=hijacked-by-env (env override should have been beaten by the programmatic value)`);
+    exitCode = 1;
+  } else {
+    console.log('OK:   no traces under hijacked-by-env (programmatic serviceName wins)');
+  }
+  process.exit(exitCode);
+}
+
+main().catch((e) => { console.error(e); process.exit(2); });

--- a/test/alloy-tempo-smoke/tempo/tempo.yml
+++ b/test/alloy-tempo-smoke/tempo/tempo.yml
@@ -1,0 +1,27 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+        http:
+          endpoint: "0.0.0.0:4318"
+
+ingester:
+  trace_idle_period: 2s
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 1h
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks

--- a/test/kind-repro/app/Dockerfile
+++ b/test/kind-repro/app/Dockerfile
@@ -1,0 +1,9 @@
+FROM docker.io/node:20-alpine
+WORKDIR /app
+COPY saidsef-tracing-node-4.0.0.tgz /app/saidsef-tracing-node-4.0.0.tgz
+COPY package.json /app/package.json
+RUN npm install --omit=dev
+COPY app.mjs /app/app.mjs
+EXPOSE 8080
+ENV NODE_OPTIONS=--unhandled-rejections=strict
+CMD ["node", "app.mjs"]

--- a/test/kind-repro/app/app.mjs
+++ b/test/kind-repro/app/app.mjs
@@ -1,0 +1,40 @@
+import {setupTracing} from '@saidsef/tracing-node';
+
+setupTracing({
+  serviceName: process.env.SERVICE_NAME || 'saidsef',
+  containerName: process.env.HOSTNAME,
+  url: process.env.ENDPOINT || 'http://alloy.monitoring.svc:4317',
+  enableDnsInstrumentation: false,
+});
+
+const express = (await import('express')).default;
+
+const ROLE = process.env.ROLE || 'frontend';
+const PORT = parseInt(process.env.PORT || '8080', 10);
+const DOWNSTREAM = process.env.DOWNSTREAM_URL;
+
+const app = express();
+
+app.get('/healthz', (_req, res) => res.status(200).send('ok'));
+
+app.get('/work', async (_req, res) => {
+  if (ROLE === 'frontend' && DOWNSTREAM) {
+    try {
+      const r = await fetch(`${DOWNSTREAM}/leaf`);
+      const body = await r.text();
+      res.json({role: ROLE, downstream: body});
+    } catch (e) {
+      res.status(500).json({error: String(e)});
+    }
+  } else {
+    res.json({role: ROLE, ok: true});
+  }
+});
+
+app.get('/leaf', (_req, res) => {
+  res.json({role: ROLE, leaf: true});
+});
+
+app.listen(PORT, '0.0.0.0', () => {
+  console.log(`${ROLE} listening on :${PORT} (downstream=${DOWNSTREAM ?? 'none'})`);
+});

--- a/test/kind-repro/app/package.json
+++ b/test/kind-repro/app/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "saidsef-repro",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "app.mjs",
+  "dependencies": {
+    "@saidsef/tracing-node": "file:./saidsef-tracing-node-4.0.0.tgz",
+    "express": "^4.21.2"
+  }
+}

--- a/test/kind-repro/manifests/saidsef.yml
+++ b/test/kind-repro/manifests/saidsef.yml
@@ -1,0 +1,94 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: apps
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: downstream
+  namespace: apps
+  labels: {app: downstream}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: downstream}
+  template:
+    metadata:
+      labels: {app: downstream}
+    spec:
+      containers:
+      - name: app
+        image: saidsef-repro:1
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: SERVICE_NAME
+          value: downstream
+        - name: ROLE
+          value: leaf
+        - name: PORT
+          value: "8080"
+        - name: ENDPOINT
+          value: http://alloy.monitoring.svc:4317
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet: {path: /healthz, port: 8080}
+          periodSeconds: 2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: downstream
+  namespace: apps
+spec:
+  selector: {app: downstream}
+  ports:
+  - port: 8080
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: saidsef
+  namespace: apps
+  labels: {app: saidsef}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: saidsef}
+  template:
+    metadata:
+      labels: {app: saidsef}
+    spec:
+      containers:
+      - name: app
+        image: saidsef-repro:1
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: SERVICE_NAME
+          value: saidsef
+        - name: ROLE
+          value: frontend
+        - name: PORT
+          value: "8080"
+        - name: ENDPOINT
+          value: http://alloy.monitoring.svc:4317
+        - name: DOWNSTREAM_URL
+          value: http://downstream.apps.svc:8080
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet: {path: /healthz, port: 8080}
+          periodSeconds: 2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: saidsef
+  namespace: apps
+spec:
+  selector: {app: saidsef}
+  ports:
+  - port: 8080
+    targetPort: 8080


### PR DESCRIPTION
4.0.0. The OTel stack was getting messy and missing a chunk of signal coverage; this cleans both up.

What changed:
- bootstrap is now NodeSDK from `@opentelemetry/sdk-node`; standard `OTEL_*` env vars are honoured (programmatic options still win)
- metrics on by default - existing http / undici / express / aws / ioredis spans now also emit RED histograms; Node runtime metrics included
- new instrumentations: undici (native fetch), gRPC, pg, mongodb, kafkajs, amqplib. DB and messaging ones only register when the target lib is actually installed in the consuming app
- `container.id` attached to spans and metrics via cgroup detector
- context manager switched to `AsyncLocalStorage`
- sampler exposed as `ParentBased(TraceIdRatioBased(samplingRatio))`, default 1.0
- OTLP HTTP/protobuf available alongside the gRPC default
- opt-in SIGTERM/SIGINT shutdown
- diag logger no longer enabled at import; opt in via `enableDiagLogging` or `OTEL_LOG_LEVEL`
- `stopTracing` fully releases the global tracer/meter providers so `setupTracing` can be called again

Removed:
- `@opentelemetry/instrumentation-connect` (Connect is dormant)
- `opentelemetry-instrumentation-elasticsearch` (unmaintained since May 2024; HTTP instrumentation still picks up ES traffic)

Tests went from 5 to 19, covering the new options, the auto-detect path, and the provider lifecycle through shutdown / re-init.