### PR TITLE
chore: drop stale fsevents allowScripts entry and bump to 3.21.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saidsef/tracing-node",
-  "version": "3.21.0",
+  "version": "3.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@saidsef/tracing-node",
-      "version": "3.21.0",
+      "version": "3.21.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saidsef/tracing-node",
-  "version": "3.21.0",
+  "version": "3.21.1",
   "description": "tracing NodeJS - Wrapper for OpenTelemetry instrumentation packages",
   "main": "libs/index.mjs",
   "scripts": {
@@ -56,7 +56,6 @@
     "@opentelemetry/core": "^2.8.0"
   },
   "allowScripts": {
-    "fsevents@2.3.3": true,
     "protobufjs@7.6.4": true
   }
 }


### PR DESCRIPTION
## Summary

- Remove the `fsevents@2.3.3` entry from `package.json` `allowScripts`. It only existed because jest's chokidar pulled fsevents on macOS; jest was removed in 3.21.0, so fsevents is no longer in the dep tree and the entry is dead config.
- Keep the `protobufjs@7.6.4` entry — that one silences a real `npm warn allow-scripts ... protobufjs@7.6.4 (postinstall: node scripts/postinstall)` warning on every `npm ci`.
- Bump version to 3.21.1.

## Test plan

- [x] `npm ci` — installs cleanly with no `allow-scripts` warnings
- [x] `npm test` — 5/5 tests pass on Node 24/25/26 (CI)
- [x] `npm audit` — reports 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)