### PR TITLE
Fix instrumentation hook signatures and drop dead config

### DIFF
--- a/libs/index.mjs
+++ b/libs/index.mjs
@@ -17,9 +17,7 @@
  */
 
 import {AwsInstrumentation} from '@opentelemetry/instrumentation-aws-sdk';
-import {AsyncHooksContextManager} from '@opentelemetry/context-async-hooks';
 import {BatchSpanProcessor} from '@opentelemetry/sdk-trace-base';
-import {CompositePropagator, W3CBaggagePropagator, W3CTraceContextPropagator} from '@opentelemetry/core';
 import {ConnectInstrumentation} from '@opentelemetry/instrumentation-connect';
 import {diag, DiagConsoleLogger, DiagLogLevel} from '@opentelemetry/api';
 import {HttpInstrumentation} from '@opentelemetry/instrumentation-http';
@@ -101,29 +99,26 @@ export function setupTracing(options = {}) {
     exportTimeoutMillis: 10000,
   });
 
+  // Explicit attributes (service/container) must win over env detection, so
+  // detect first and merge the explicit resource on top. Only include defined
+  // keys so an undefined hostname does not write container.name: undefined.
+  const explicitAttributes = {[ATTR_SERVICE_NAME]: serviceName};
+  if (hostname) {
+    explicitAttributes[ATTR_CONTAINER_NAME] = hostname;
+  }
+
   tracerProvider = new NodeTracerProvider({
     spanProcessors: [spanProcessor],
-    resource: new resourceFromAttributes({
-      [ATTR_SERVICE_NAME]: serviceName,
-      [ATTR_CONTAINER_NAME]: hostname,
-    }).merge(
-      detectResources({
-        detectors: [envDetector, hostDetector, osDetector, processDetector, serviceInstanceIdDetector],
-      })
-    ),
-    autoDetectResources: true,
+    resource: detectResources({
+      detectors: [envDetector, hostDetector, osDetector, processDetector, serviceInstanceIdDetector],
+    }).merge(resourceFromAttributes(explicitAttributes)),
   });
 
-  // Initialize the tracer provider with propagators
-  tracerProvider.register({
-    contextManager: new AsyncHooksContextManager().enable(),
-    propagator: new CompositePropagator({
-    propagators: [
-      new W3CTraceContextPropagator(),
-      new W3CBaggagePropagator(),
-      ],
-    }),
-  });
+  // Register globally. With no overrides, register() installs the modern
+  // AsyncLocalStorageContextManager and a CompositePropagator of
+  // W3CTraceContext + W3CBaggage - identical propagation to the previous
+  // explicit config, with the recommended context manager.
+  tracerProvider.register();
 
   // Ignore spans from static assets.
   const ignoreIncomingRequestHook = (req) => {
@@ -207,89 +202,68 @@ export function setupTracing(options = {}) {
       },
     }),
     new ExpressInstrumentation({
-      ignoreIncomingRequestHook,
-      requestHook: (span, request) => {
-        // Add Express-specific attributes
-        if (request.route?.path) {
-          span.setAttribute('express.route', request.route.path);
-          span.updateName(`${request.method} ${request.route.path}`);
+      requestHook: (span, info) => {
+        // info is ExpressRequestInfo: { request, route, layerType }
+        const request = info.request;
+        if (info.route) {
+          span.setAttribute('express.route', info.route);
+          if (request?.method) {
+            span.updateName(`${request.method} ${info.route}`);
+          }
         }
-        if (request.params && Object.keys(request.params).length > 0) {
+        if (request?.params && Object.keys(request.params).length > 0) {
           span.setAttribute('express.params', JSON.stringify(request.params));
         }
-        if (request.query && Object.keys(request.query).length > 0) {
+        if (request?.query && Object.keys(request.query).length > 0) {
           span.setAttribute('express.query', JSON.stringify(request.query));
         }
         // Add user context if available
-        if (request.user?.id) {
+        if (request?.user?.id) {
           span.setAttribute('user.id', request.user.id);
         }
       },
     }),
     new PinoInstrumentation({
       logHook: (span, record) => {
-        // Inject trace context into log records
-        const spanContext = span.spanContext();
-        record['trace_id'] = spanContext.traceId;
-        record['span_id'] = spanContext.spanId;
-        record['trace_flags'] = `0${spanContext.traceFlags.toString(16)}`;
-
-        // Add service name for better log correlation
+        // trace_id/span_id/trace_flags are injected by the instrumentation by
+        // default; only add service name for better log correlation.
         if (serviceName) {
           record['service.name'] = serviceName;
         }
       },
-      logSeverity: {
-        error: 'ERROR',
-        warn: 'WARN',
-        info: 'INFO',
-        debug: 'DEBUG',
-        trace: 'TRACE',
-      },
     }),
-    new ConnectInstrumentation({
-      ignoreIncomingRequestHook,
-      requestHook: (span, request) => {
-        // Add Connect middleware attributes
-        if (request.url) {
-          span.setAttribute('connect.url', request.url);
-        }
-        if (request.method) {
-          span.setAttribute('connect.method', request.method);
-        }
-      },
-    }),
+    // ConnectInstrumentation accepts only the base InstrumentationConfig; it has
+    // no request/ignore hooks, so configure it with defaults.
+    new ConnectInstrumentation(),
     new AwsInstrumentation({
       suppressInternalInstrumentation: false,
       sqsExtractContextPropagationFromPayload: true,
-      preRequestHook: (span, request) => {
-        // Add peer.service attribute for better service map visualization
-        const serviceName = request.serviceName || request.service?.serviceIdentifier;
-        if (serviceName) {
-          span.setAttribute('peer.service', serviceName.toLowerCase());
-          span.setAttribute('aws.service', serviceName.toLowerCase());
+      preRequestHook: (span, requestInfo) => {
+        // requestInfo is AwsSdkRequestHookInformation: { request: NormalizedRequest }
+        const awsServiceName = requestInfo.request?.serviceName;
+        if (awsServiceName) {
+          span.setAttribute('peer.service', awsServiceName.toLowerCase());
+          span.setAttribute('aws.service', awsServiceName.toLowerCase());
         }
       },
-      responseHook: (span, response) => {
-        // Add additional attributes from response if available
-        if (response?.requestId) {
-          span.setAttribute('aws.request_id', response.requestId);
+      responseHook: (span, responseInfo) => {
+        // responseInfo is AwsSdkResponseHookInformation: { response: NormalizedResponse }
+        const requestId = responseInfo.response?.requestId;
+        if (requestId) {
+          span.setAttribute('aws.request_id', requestId);
         }
       },
     }),
     new IORedisInstrumentation({
       requireParentSpan: false,
-      requestHook: (span, cmdName, cmdArgs) => {
-        // Set peer.service for service graph visualization - CRITICAL for Tempo
+      requestHook: (span, {cmdName, cmdArgs}) => {
+        // requestInfo is IORedisRequestHookInformation: { cmdName, cmdArgs }.
+        // Set peer.service for service graph visualization - CRITICAL for Tempo.
+        // The span is already created with SpanKind.CLIENT and net.peer.name is
+        // already set to the real host by the instrumentation, so we do not
+        // override those here.
         span.setAttribute('peer.service', 'redis');
         span.setAttribute('db.system', 'redis');
-        
-        // CRITICAL: Ensure span kind is CLIENT for service graph
-        span.setAttribute('span.kind', 'CLIENT');
-        
-        // Add network peer attributes (helps Tempo identify the service)
-        span.setAttribute('net.peer.name', 'redis');
-        span.setAttribute('db.connection_string', 'redis');
 
         // Add command details for better observability
         if (cmdName) {
@@ -348,56 +322,10 @@ export function setupTracing(options = {}) {
   if (enableDnsInstrumentation) {
     // Enable DNS instrumentation if specified
     // This instrumentation is useful for tracing DNS operations.
+    // DnsInstrumentationConfig only supports ignoreHostnames; it has no
+    // request/response/error hooks.
     instrumentations.push(new DnsInstrumentation({
       ignoreHostnames: ['localhost', '127.0.0.1', '::1'],
-      requestHook: (span, request) => {
-        // Add DNS query details for better observability
-        if (request.hostname) {
-          span.setAttribute('dns.hostname', request.hostname);
-          span.updateName(`DNS ${request.hostname}`);
-        }
-        if (request.rrtype) {
-          span.setAttribute('dns.record_type', request.rrtype);
-        }
-        // Add additional context
-        span.setAttribute('peer.service', 'dns');
-        span.setAttribute('dns.query_count', 1);
-      },
-      responseHook: (span, response) => {
-        // Add DNS response details
-        if (Array.isArray(response)) {
-          span.setAttribute('dns.result_count', response.length);
-          // Log first few results for debugging (limit to avoid overwhelming spans)
-          const resultSample = response.slice(0, 3).map(r => 
-            typeof r === 'string' ? r : JSON.stringify(r)
-          );
-          if (resultSample.length > 0) {
-            span.setAttribute('dns.results', JSON.stringify(resultSample));
-          }
-        } else if (response) {
-          span.setAttribute('dns.result_count', 1);
-          span.setAttribute('dns.result', typeof response === 'string' ? response : JSON.stringify(response));
-        }
-      },
-      errorHook: (span, error) => {
-        // Enhanced error tracking for DNS failures
-        if (error) {
-          span.setAttribute('dns.error', true);
-          span.setAttribute('dns.error.code', error.code || 'UNKNOWN');
-          span.setAttribute('dns.error.message', error.message || 'DNS lookup failed');
-
-          // Categorize common DNS errors
-          if (error.code === 'ENOTFOUND') {
-            span.setAttribute('dns.error.type', 'NOT_FOUND');
-          } else if (error.code === 'ETIMEOUT') {
-            span.setAttribute('dns.error.type', 'TIMEOUT');
-          } else if (error.code === 'ECONNREFUSED') {
-            span.setAttribute('dns.error.type', 'CONNECTION_REFUSED');
-          } else {
-            span.setAttribute('dns.error.type', 'OTHER');
-          }
-        }
-      },
     }));
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^2.8.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.219.0",
         "@opentelemetry/instrumentation": "^0.219.0",
         "@opentelemetry/instrumentation-aws-sdk": "^0.74.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saidsef/tracing-node",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@saidsef/tracing-node",
-      "version": "3.21.0",
+      "version": "3.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saidsef/tracing-node",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "description": "tracing NodeJS - Wrapper for OpenTelemetry instrumentation packages",
   "main": "libs/index.mjs",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "homepage": "https://github.com/saidsef/tracing-node#readme",
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/context-async-hooks": "^2.8.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.219.0",
     "@opentelemetry/instrumentation": "^0.219.0",
     "@opentelemetry/instrumentation-aws-sdk": "^0.74.0",
@@ -56,7 +55,6 @@
     "@opentelemetry/core": "^2.8.0"
   },
   "allowScripts": {
-    "fsevents@2.3.3": true,
     "protobufjs@7.6.4": true
   }
 }

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,0 +1,23 @@
+# Build context = repo root:
+#   docker build -t tracing-e2e-demo:local -f test/e2e/Dockerfile .
+FROM node:22-slim
+
+WORKDIR /app
+
+# Install the tracing-node library's own prod deps (the @opentelemetry/* packages
+# that libs/index.mjs imports). All are pure-JS, so no build toolchain is needed.
+COPY package.json package-lock.json ./
+COPY libs ./libs
+RUN npm ci --omit=dev
+
+# Consumer libraries the demo app instruments (not deps of tracing-node).
+RUN npm install --no-save express@^4 ioredis@^5 pino@^9
+
+# Demo app + tracing preload (placed at /app so ./libs/index.mjs resolves).
+COPY test/e2e/app.cjs test/e2e/instrument.mjs ./
+
+ENV NODE_ENV=production
+EXPOSE 8080
+
+# --import runs the ESM tracing preload to completion before the CJS app loads.
+CMD ["node", "--import", "./instrument.mjs", "./app.cjs"]

--- a/test/e2e/app.cjs
+++ b/test/e2e/app.cjs
@@ -1,0 +1,43 @@
+'use strict';
+
+// CommonJS so @opentelemetry/instrumentation patches express/ioredis/http via
+// require-in-the-middle (no ESM loader flags needed). Tracing is initialised by
+// instrument.mjs (node --import) before this module loads.
+const express = require('express');
+const Redis = require('ioredis');
+const pino = require('pino');
+
+const logger = pino({level: process.env.LOG_LEVEL || 'info'});
+const PORT = parseInt(process.env.PORT || '8080', 10);
+
+const redis = new Redis({
+  host: process.env.REDIS_HOST || 'redis',
+  port: parseInt(process.env.REDIS_PORT || '6379', 10),
+  maxRetriesPerRequest: 2,
+  lazyConnect: false,
+});
+
+redis.on('error', (err) => logger.error({err: err.message}, 'redis error'));
+redis.on('connect', () => logger.info('redis connected'));
+
+const app = express();
+
+app.get('/healthz', (req, res) => res.status(200).send('ok'));
+
+// Exercises HTTP (server span) + Express (route span) + IORedis (SET/GET) +
+// Pino (trace context injection) in a single request.
+app.get('/work/:id', async (req, res) => {
+  const id = req.params.id;
+  const key = `key:${id}`;
+  try {
+    await redis.set(key, `hello-${id}`, 'EX', 60);
+    const val = await redis.get(key);
+    logger.info({id, key, val}, 'handled work');
+    res.json({id, key, val});
+  } catch (err) {
+    logger.error({id, err: err.message}, 'work failed');
+    res.status(500).json({error: err.message});
+  }
+});
+
+app.listen(PORT, () => logger.info({port: PORT}, 'demo listening'));

--- a/test/e2e/instrument.mjs
+++ b/test/e2e/instrument.mjs
@@ -1,0 +1,7 @@
+// E2E tracing preload. Run via: node --import ./instrument.mjs ./app.cjs
+// Initialises the LOCAL tracing-node library (libs/index.mjs) before the app
+// loads, so its instrumentations patch express/ioredis/http on require.
+// serviceName + url are read from SERVICE_NAME and ENDPOINT env vars.
+import {setupTracing} from './libs/index.mjs';
+
+setupTracing();

--- a/test/e2e/k8s/demo.yml
+++ b/test/e2e/k8s/demo.yml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo
+  namespace: monitoring
+  labels:
+    app: demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demo
+  template:
+    metadata:
+      labels:
+        app: demo
+    spec:
+      # Avoid k8s injecting REDIS_PORT=tcp://<ip>:6379 (service links), which
+      # would break parseInt(REDIS_PORT).
+      enableServiceLinks: false
+      containers:
+        - name: demo
+          image: tracing-e2e-demo:local
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          env:
+            - name: SERVICE_NAME
+              value: tracing-e2e-demo
+            - name: ENDPOINT
+              value: "http://alloy.monitoring.svc.cluster.local:4317"
+            - name: REDIS_HOST
+              value: redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: CONTAINER_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              memory: "256Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo
+  namespace: monitoring
+spec:
+  selector:
+    app: demo
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/test/e2e/k8s/redis.yml
+++ b/test/e2e/k8s/redis.yml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: monitoring
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          args: ["--save", "", "--appendonly", "no"]
+          ports:
+            - containerPort: 6379
+          readinessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: "25m"
+              memory: "64Mi"
+            limits:
+              memory: "128Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: monitoring
+spec:
+  selector:
+    app: redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379


### PR DESCRIPTION
## What

The instrumentation hooks in `libs/index.mjs` were written for an older OpenTelemetry API. In 2.x several hooks receive an info object as their second argument rather than the raw value, so the IORedis, Express and AWS hooks were reading fields off the wrong object and never set the attributes they intended. The IORedis request hook went further and called `cmdName.toUpperCase()` on an object, throwing on every Redis command (the error was swallowed by `safeExecuteInTheMiddle`, so it failed silently). This corrects the argument handling and removes config that the installed instrumentations quietly ignore.

## Changes

- IORedis/Express/AWS hooks now read from the info object (`{cmdName, cmdArgs}`, `{request, route}`, `{request}`/`{response}`), restoring `db.operation`, `db.redis.key`, `express.route`, the `redis.<CMD>` / `METHOD /route` span renames and the AWS peer/request-id attributes.
- Dropped dead config the installed instrumentations ignore: Connect request/ignore hooks, Express `ignoreIncomingRequestHook`, Pino `logSeverity`, DNS request/response/error hooks, and the provider `autoDetectResources` flag.
- Resource merge now lets an explicit `serviceName` take precedence over `OTEL_SERVICE_NAME` instead of the other way round.
- `register()` is called without overrides so it installs the default AsyncLocalStorage context manager and W3C propagators; this drops the direct import of `@opentelemetry/core`, which was not a declared dependency.
- Removed the leftover `new` on the `resourceFromAttributes` factory and the redundant Pino trace-field injection that the instrumentation already performs.
- Removed the now-unused `@opentelemetry/context-async-hooks` dependency (still available transitively via `sdk-trace-node`) and the dead `fsevents` allowScripts entry.
- Bumped version to 3.22.0.

## Testing

- `npm test` and `npm run lint` pass.
- Added `test/e2e`, a small Express + ioredis + pino app that uses the library and runs in a kind cluster, sending traces through Alloy to Tempo. Confirmed in Tempo that the `redis.SET`/`redis.GET` spans carry `db.operation` and `db.redis.key`, the Express span is named `GET /work/:id` with `express.route`, and Pino logs carry `trace_id`/`span_id`/`service.name`.