### PR TITLE
chore(instrumentation): trim redundant span writes and de-duplicate hooks

### DIFF
--- a/libs/index.mjs
+++ b/libs/index.mjs
@@ -36,6 +36,15 @@ import {ATTR_CONTAINER_NAME} from '@opentelemetry/semantic-conventions/incubatin
 
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
 
+// Set a non-negative integer span attribute from a header value; ignore invalid input.
+const setIntAttribute = (span, name, value) => {
+  if (!value) return;
+  const parsed = parseInt(value, 10);
+  if (!Number.isNaN(parsed) && parsed >= 0) {
+    span.setAttribute(name, parsed);
+  }
+};
+
 /**
 * Sets up tracing for the application using OpenTelemetry.
 *
@@ -120,11 +129,6 @@ export function setupTracing(options = {}) {
   // explicit config, with the recommended context manager.
   tracerProvider.register();
 
-  // Ignore spans from static assets.
-  const ignoreIncomingRequestHook = (req) => {
-    return req.url.startsWith('/metrics') || req.url.startsWith('/healthz');
-  };
-
   // Hook to set peer service name for outgoing requests
   const applyCustomAttributesOnSpan = (span, request) => {
     const url = request?.url || request?.uri || '';
@@ -149,7 +153,8 @@ export function setupTracing(options = {}) {
   const instrumentations = [
     new HttpInstrumentation({
       serverName: serviceName,
-      ignoreIncomingRequestHook,
+      // Ignore spans from static assets (metrics/health probes).
+      ignoreIncomingRequestHook: (req) => req.url.startsWith('/metrics') || req.url.startsWith('/healthz'),
       applyCustomAttributesOnSpan,
       requestHook: (span, request) => {
         // Enrich spans with additional HTTP request attributes
@@ -168,13 +173,7 @@ export function setupTracing(options = {}) {
         if (userAgent) span.setAttribute('http.user_agent', userAgent);
         if (contentType) span.setAttribute('http.request.content_type', contentType);
 
-        // Safe integer parsing with validation
-        if (contentLength) {
-          const length = parseInt(contentLength, 10);
-          if (!Number.isNaN(length) && length >= 0) {
-            span.setAttribute('http.request.content_length', length);
-          }
-        }
+        setIntAttribute(span, 'http.request.content_length', contentLength);
 
         // Correlation headers for distributed tracing
         if (requestId) span.setAttribute('http.request_id', requestId);
@@ -191,12 +190,7 @@ export function setupTracing(options = {}) {
 
         if (contentType) span.setAttribute('http.response.content_type', contentType);
 
-        if (contentLength) {
-          const length = parseInt(contentLength, 10);
-          if (!Number.isNaN(length) && length >= 0) {
-            span.setAttribute('http.response.content_length', length);
-          }
-        }
+        setIntAttribute(span, 'http.response.content_length', contentLength);
 
         if (requestId) span.setAttribute('http.request_id', requestId);
       },
@@ -282,20 +276,11 @@ export function setupTracing(options = {}) {
         }
       },
       responseHook: (span, cmdName, cmdArgs, response) => {
-        // Ensure peer.service persists through response
-        span.setAttribute('peer.service', 'redis');
-        span.setAttribute('db.system', 'redis');
-
-        // Add command details for better observability
-        if (cmdName) {
-          span.setAttribute('db.operation', cmdName.toUpperCase());
-        }
-
-        // Log response size if available
+        // peer.service, db.system and db.operation are already set on this span
+        // by requestHook and persist for the span's lifetime, so they are not
+        // re-set here. Record only the response shape for observability.
         if (response !== undefined && response !== null) {
-          const responseType = typeof response;
-          span.setAttribute('db.response.type', responseType);
-
+          span.setAttribute('db.response.type', typeof response);
           if (Array.isArray(response)) {
             span.setAttribute('db.response.count', response.length);
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saidsef/tracing-node",
-  "version": "3.22.0",
+  "version": "3.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@saidsef/tracing-node",
-      "version": "3.22.0",
+      "version": "3.22.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saidsef/tracing-node",
-  "version": "3.22.0",
+  "version": "3.22.1",
   "description": "tracing NodeJS - Wrapper for OpenTelemetry instrumentation packages",
   "main": "libs/index.mjs",
   "scripts": {


### PR DESCRIPTION
## What

Three small, behaviour-preserving cleanups to `libs/index.mjs` that remove redundant work and duplicated code. No change to the spans this library emits.

## Changes

- **IORedis `responseHook`**: stop re-setting `peer.service`, `db.system` and `db.operation`. The `requestHook` already sets these on the same span at command start and they persist for the span's lifetime, so the response-side writes ran on every Redis command for no effect. The comment claiming the re-set was needed "so peer.service persists through response" was incorrect and has been removed. The genuinely response-specific attributes (`db.response.type`, `db.response.count`) are kept.
- **HTTP hooks**: the `content_length` parse-and-validate block was duplicated verbatim in the request and response hooks. Extracted into a single `setIntAttribute` helper and called from both.
- **`ignoreIncomingRequestHook`**: it was declared as a local const and used once. Inlined into the `HttpInstrumentation` config.

## Why

Smaller surface, one source of truth for the integer-attribute logic, and a bit less per-request/per-command work in the hot instrumentation hooks. The old Redis comment was also actively misleading.

## Safety / no regression

- The completed Redis span carries the same attribute set as before, since the removed writes were already made with identical values by `requestHook`.
- The HTTP and inline changes are pure extraction/inlining with identical runtime behaviour.
- A previously considered change - dropping the `|| headers['User-Agent']` case-insensitive header fallbacks - was deliberately left out. `HttpInstrumentation.requestHook` also fires for outgoing client requests, where callers can set mixed-case header names, so removing the fallback could drop attributes.

## Testing

- `npm run lint` - passes, no warnings.
- `npm test` - all 5 unit tests pass.

Net result: 15 fewer lines in `libs/index.mjs`. Patch version bump to 3.22.1.
