### PR TITLE
chore(deps): bump instrumentation-fs and eslint, release 3.22.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saidsef/tracing-node",
-  "version": "3.22.4",
+  "version": "3.22.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@saidsef/tracing-node",
-      "version": "3.22.4",
+      "version": "3.22.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -16,7 +16,7 @@
         "@opentelemetry/instrumentation-connect": "^0.63.0",
         "@opentelemetry/instrumentation-dns": "^0.64.0",
         "@opentelemetry/instrumentation-express": "^0.67.0",
-        "@opentelemetry/instrumentation-fs": "^0.38.0",
+        "@opentelemetry/instrumentation-fs": "^0.40.0",
         "@opentelemetry/instrumentation-http": "^0.220.0",
         "@opentelemetry/instrumentation-ioredis": "^0.68.0",
         "@opentelemetry/instrumentation-pino": "^0.66.0",
@@ -91,9 +91,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -443,13 +443,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fs": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.38.0.tgz",
-      "integrity": "sha512-6OBofWODg0RcPkl3bA+7yPf0e4Vi3O7ZxlFGY5QHPMMLxWVMnjWPEXQ2NlLBk19Sr8LcvEyyZOStdLJrT5o2dQ==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.40.0.tgz",
+      "integrity": "sha512-p39axaaYVKhnl5l4M+1aiXmxrAG2HuTti7DHxs2jDJRst828y5iwqUZLC1UWIKIhW9FfdV5gogXg+nRRhSc0EA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.219.0"
+        "@opentelemetry/core": "^2.9.0",
+        "@opentelemetry/instrumentation": "^0.221.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -459,9 +459,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fs/node_modules/@opentelemetry/api-logs": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.219.0.tgz",
-      "integrity": "sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -471,12 +471,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fs/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.219.0.tgz",
-      "integrity": "sha512-X5t7I8GyIO9rmGHwoedZLREpQqrF1WW2nxzNNym6HOKpFiE+rvqV3ngC0xcZVO2YwIGf3KKmRdWrYwdwz3H9RQ==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.221.0.tgz",
+      "integrity": "sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.219.0",
+        "@opentelemetry/api-logs": "0.221.0",
         "import-in-the-middle": "^3.0.0",
         "require-in-the-middle": "^8.0.0"
       },
@@ -1026,9 +1026,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
-      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -1038,7 +1038,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -1062,7 +1062,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saidsef/tracing-node",
-  "version": "3.22.5",
+  "version": "3.22.6",
   "description": "tracing NodeJS - Wrapper for OpenTelemetry instrumentation packages",
   "main": "libs/index.mjs",
   "scripts": {
@@ -37,7 +37,7 @@
     "@opentelemetry/instrumentation-connect": "^0.63.0",
     "@opentelemetry/instrumentation-dns": "^0.64.0",
     "@opentelemetry/instrumentation-express": "^0.67.0",
-    "@opentelemetry/instrumentation-fs": "^0.38.0",
+    "@opentelemetry/instrumentation-fs": "^0.40.0",
     "@opentelemetry/instrumentation-http": "^0.220.0",
     "@opentelemetry/instrumentation-ioredis": "^0.68.0",
     "@opentelemetry/instrumentation-pino": "^0.66.0",


### PR DESCRIPTION
Rolls the two open dependabot PRs into one update so we get a single lockfile change and a single release, rather than two rounds of CI and a merge conflict between them (both touch `package-lock.json`).

## What changed

| Package | From | To | Type |
| --- | --- | --- | --- |
| `@opentelemetry/instrumentation-fs` | 0.38.0 | 0.40.0 | production |
| `eslint` | 10.6.0 | 10.8.0 | development |

Package version bumped 3.22.5 -> 3.22.6.

The `eslint` bump is lockfile-only - the existing `^10.5.0` range already allows 10.8.0, so `package.json` is unchanged for it. `instrumentation-fs` needed the range widened to `^0.40.0`, which also pulls its bundled `@opentelemetry/instrumentation` and `api-logs` from 0.219.0 to 0.221.0.

One incidental fix: the `version` field inside `package-lock.json` had drifted to 3.22.4 while `package.json` said 3.22.5. Regenerating the lock brings both to 3.22.6.

## Verification

- `npm run lint` - clean
- `npm test` - 5/5 passing

## Notes

Supersedes #536 and #537. Both are left open and untouched - close them once this merges.

`npm audit` still reports a high-severity advisory for `brace-expansion` (GHSA-mh99-v99m-4gvg). It predates this change and is out of scope here; worth a follow-up.
