### PR TITLE
chore(deps): bump opentelemetry packages to stable semconv, release 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,33 @@ Effortlessly supercharge your applications with world-class distributed tracing!
 npm install @saidsef/tracing-node --save
 ```
 
+## Upgrading to 4.0.0
+
+**Breaking change: spans now carry the stable OpenTelemetry semantic conventions.**
+
+The upstream instrumentations ([open-telemetry/opentelemetry-js-contrib#3585](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3585)) dropped the legacy attributes and removed the `OTEL_SEMCONV_STABILITY_OPT_IN` escape hatch, so there is no way to keep the old names. The public API of `setupTracing` / `stopTracing` is unchanged - no code changes are required - but any dashboard, alert or processor keyed on the old attribute names must be updated.
+
+| Removed | Replacement | Affected spans |
+|---------|-------------|----------------|
+| `http.method` | `http.request.method` | HTTP |
+| `http.status_code` | `http.response.status_code` | HTTP, AWS SDK |
+| `http.url` | `url.full` | HTTP |
+| `http.target` | `url.path` + `url.query` | HTTP |
+| `http.scheme` | `url.scheme` | HTTP |
+| `http.user_agent` | `user_agent.original` | HTTP |
+| `http.client_ip` | `client.address` | HTTP |
+| `http.flavor` | `network.protocol.version` | HTTP |
+| `net.peer.name` | `server.address` | HTTP, IORedis |
+| `net.peer.port` | `server.port` | HTTP, IORedis |
+| `db.system` | `db.system.name` | IORedis, DynamoDB |
+| `db.statement` | `db.query.text` | IORedis, DynamoDB |
+| `db.operation` | `db.operation.name` | IORedis, DynamoDB |
+| `db.connection_string` | none | IORedis |
+
+Server-side HTTP metrics also move from `http.server.duration` (milliseconds) to `http.server.request.duration` (seconds), and the client equivalents likewise.
+
+`peer.service` is unchanged, so Tempo/Grafana service graphs keep working as before. IORedis spans also gain `db.operation.name`, which distinguishes `MULTI`/`PIPELINE` commands.
+
 ## Usage
 
 You can set required params via env variables or function:

--- a/libs/index.mjs
+++ b/libs/index.mjs
@@ -43,6 +43,15 @@ const setIntAttribute = (span, name, value) => {
   }
 };
 
+// Slice before converting: String(buf) decodes a whole 1MB Buffer only to throw
+// it away. 4 bytes per UTF-16 unit plus slack keeps the result byte-identical.
+const truncateArg = (value, limit) => {
+  const str = Buffer.isBuffer(value) ? value.subarray(0, limit * 4 + 8).toString() : String(value);
+  return str.length > limit ? `${str.substring(0, limit)}...` : str;
+};
+
+let tracerProvider = null; // Declare provider in module scope for access in stopTracing
+
 /**
 * Sets up tracing for the application using OpenTelemetry.
 *
@@ -53,7 +62,7 @@ const setIntAttribute = (span, name, value) => {
 * service map visualization in distributed tracing tools like Tempo.
 *
 * @param {Object} options - Configuration options for tracing.
-* @param {string} [options.hostname=process.env.HOSTNAME] - The hostname of the service.
+* @param {string} [options.hostname=process.env.CONTAINER_NAME || process.env.HOSTNAME] - The hostname of the service.
 * @param {string} [options.serviceName=process.env.SERVICE_NAME] - The name of the service.
 * @param {string} [options.url=process.env.ENDPOINT] - The endpoint URL for the tracing collector.
 * @param {number} [options.concurrencyLimit=10] - The concurrency limit for the exporter.
@@ -62,12 +71,10 @@ const setIntAttribute = (span, name, value) => {
 *
 * @returns {Tracer} - The tracer for the service.
 */
-let tracerProvider = null; // Declare provider in module scope for access in stopTracing
-
 export function setupTracing(options = {}) {
   // Prevent multiple initializations - return existing provider if already set up
   if (tracerProvider) {
-    console.warn('Tracing is already initialized. Returning existing tracer.');
+    diag.warn('Tracing is already initialized. Returning existing tracer.');
     return tracerProvider.getTracer(options.serviceName || process.env.SERVICE_NAME);
   }
 
@@ -95,10 +102,8 @@ export function setupTracing(options = {}) {
     timeoutMillis: 10000,
   };
 
-  // Register the span processor with the tracer provider
   const exporter = new OTLPTraceExporter(exportOptions);
 
-  // Configure BatchSpanProcessor for production workloads
   const spanProcessor = new BatchSpanProcessor(exporter, {
     maxQueueSize: 4096,
     maxExportBatchSize: 1024,
@@ -127,69 +132,49 @@ export function setupTracing(options = {}) {
   // explicit config, with the recommended context manager.
   tracerProvider.register();
 
-  // Hook to set peer service name for outgoing requests
+  // Only an outgoing ClientRequest carries .host, so bailing without it keeps
+  // server spans out: peer.service must name the remote service being called.
   const applyCustomAttributesOnSpan = (span, request) => {
-    const url = request?.url || request?.uri || '';
-    const hostname = request?.hostname || request?.host || '';
-    
-    // Detect Elasticsearch endpoints
-    if (hostname.includes('elasticsearch') || url.includes('elasticsearch') || 
-        hostname.includes(':9200') || url.includes(':9200')) {
-      span.setAttribute('peer.service', 'elasticsearch');
-      span.setAttribute('db.system', 'elasticsearch');
-    }
+    const host = request?.host;
+    if (!host) return;
 
-    // Detect Redis endpoints
-    if (hostname.includes('redis') || url.includes('redis') || 
-        hostname.includes(':6379') || url.includes(':6379')) {
-      span.setAttribute('peer.service', 'redis');
-      span.setAttribute('db.system', 'redis');
+    for (const service of ['elasticsearch', 'redis']) {
+      if (host.includes(service)) {
+        span.setAttribute('peer.service', service);
+        span.setAttribute('db.system.name', service);
+        return;
+      }
     }
   };
 
-  // Register instrumentations
   const instrumentations = [
     new HttpInstrumentation({
-      serverName: serviceName,
       // Ignore spans from static assets (metrics/health probes).
       ignoreIncomingRequestHook: (req) => req.url.startsWith('/metrics') || req.url.startsWith('/healthz'),
       applyCustomAttributesOnSpan,
       requestHook: (span, request) => {
-        // Enrich spans with additional HTTP request attributes
-        if (!request.headers) return;
+        // Outgoing ClientRequest exposes getHeaders(); incoming IncomingMessage has .headers.
+        const headers = request.getHeaders?.() ?? request.headers;
+        if (!headers) return;
 
-        const headers = request.headers;
+        const contentType = headers['content-type'];
+        const requestId = headers['x-request-id'];
+        const correlationId = headers['x-correlation-id'];
 
-        // Safe header extraction with case-insensitive fallback
-        const userAgent = headers['user-agent'] || headers['User-Agent'];
-        const contentType = headers['content-type'] || headers['Content-Type'];
-        const contentLength = headers['content-length'] || headers['Content-Length'];
-        const requestId = headers['x-request-id'] || headers['X-Request-ID'];
-        const correlationId = headers['x-correlation-id'] || headers['X-Correlation-ID'];
-
-        // Only set attributes if values exist
-        if (userAgent) span.setAttribute('http.user_agent', userAgent);
         if (contentType) span.setAttribute('http.request.content_type', contentType);
-
-        setIntAttribute(span, 'http.request.content_length', contentLength);
-
-        // Correlation headers for distributed tracing
+        setIntAttribute(span, 'http.request.content_length', headers['content-length']);
         if (requestId) span.setAttribute('http.request_id', requestId);
         if (correlationId) span.setAttribute('http.correlation_id', correlationId);
       },
       responseHook: (span, response) => {
-        // Add response attributes for better observability
         if (!response.headers) return;
 
         const headers = response.headers;
-        const contentType = headers['content-type'] || headers['Content-Type'];
-        const contentLength = headers['content-length'] || headers['Content-Length'];
-        const requestId = headers['x-request-id'] || headers['X-Request-ID'];
+        const contentType = headers['content-type'];
+        const requestId = headers['x-request-id'];
 
         if (contentType) span.setAttribute('http.response.content_type', contentType);
-
-        setIntAttribute(span, 'http.response.content_length', contentLength);
-
+        setIntAttribute(span, 'http.response.content_length', headers['content-length']);
         if (requestId) span.setAttribute('http.request_id', requestId);
       },
     }),
@@ -249,17 +234,12 @@ export function setupTracing(options = {}) {
     new IORedisInstrumentation({
       requireParentSpan: false,
       requestHook: (span, {cmdName, cmdArgs}) => {
-        // requestInfo is IORedisRequestHookInformation: { cmdName, cmdArgs }.
-        // Set peer.service for service graph visualization - CRITICAL for Tempo.
-        // The span is already created with SpanKind.CLIENT and net.peer.name is
-        // already set to the real host by the instrumentation, so we do not
-        // override those here.
+        // peer.service drives the Tempo service graph and is never emitted by
+        // the instrumentation, so it has to be set here. db.system.name,
+        // db.operation.name and server.* already come from the instrumentation.
         span.setAttribute('peer.service', 'redis');
-        span.setAttribute('db.system', 'redis');
 
-        // Add command details for better observability
         if (cmdName) {
-          span.setAttribute('db.operation', cmdName.toUpperCase());
           span.updateName(`redis.${cmdName.toUpperCase()}`);
         }
 
@@ -274,9 +254,8 @@ export function setupTracing(options = {}) {
         }
       },
       responseHook: (span, cmdName, cmdArgs, response) => {
-        // peer.service, db.system and db.operation are already set on this span
-        // by requestHook and persist for the span's lifetime, so they are not
-        // re-set here. Record only the response shape for observability.
+        // peer.service is already set by requestHook and persists for the
+        // span's lifetime, so only the response shape is recorded here.
         if (response !== undefined && response !== null) {
           span.setAttribute('db.response.type', typeof response);
           if (Array.isArray(response)) {
@@ -285,37 +264,22 @@ export function setupTracing(options = {}) {
         }
       },
       dbStatementSerializer: (cmdName, cmdArgs) => {
-        // Serialize command for better observability (limit arg length to avoid huge spans)
-        const args = cmdArgs.map(arg => {
-          const str = String(arg);
-          return str.length > 100 ? `${str.substring(0, 100)}...` : str;
-        });
+        const args = cmdArgs.map(arg => truncateArg(arg, 100));
         return `${cmdName} ${args.join(' ')}`;
       },
     }),
     new ElasticsearchInstrumentation(),
+    // Spread so the optional instrumentations are constructed only when enabled:
+    // FsInstrumentation patches fs on construction.
+    ...(enableFsInstrumentation ? [new FsInstrumentation()] : []),
+    // DnsInstrumentationConfig accepts only ignoreHostnames; it has no hooks.
+    ...(enableDnsInstrumentation ? [new DnsInstrumentation({ignoreHostnames: ['localhost', '127.0.0.1', '::1']})] : []),
   ];
-
-  if (enableFsInstrumentation) {
-    // Enable fs instrumentation if specified
-    // This instrumentation is useful for tracing file system operations.
-    instrumentations.push(new FsInstrumentation());
-  }
-
-  if (enableDnsInstrumentation) {
-    // Enable DNS instrumentation if specified
-    // This instrumentation is useful for tracing DNS operations.
-    // DnsInstrumentationConfig only supports ignoreHostnames; it has no
-    // request/response/error hooks.
-    instrumentations.push(new DnsInstrumentation({
-      ignoreHostnames: ['localhost', '127.0.0.1', '::1'],
-    }));
-  }
 
   // Register instrumentations
   registerInstrumentations({
-    tracerProvider: tracerProvider,
-    instrumentations: instrumentations,
+    tracerProvider,
+    instrumentations,
   });
 
   // Return the tracer for the service
@@ -336,12 +300,12 @@ export async function stopTracing() {
     try {
       await tracerProvider.shutdown();
       tracerProvider = null;
-      console.info('Tracing has been successfully shut down.');
+      diag.info('Tracing has been successfully shut down.');
     } catch (error) {
-      console.error('Error during tracing shutdown:', error);
+      diag.error('Error during tracing shutdown:', error);
     }
   } else {
-    console.warn('Tracer provider is not initialized.');
+    diag.warn('Tracer provider is not initialized.');
   }
 }
 

--- a/libs/index.test.mjs
+++ b/libs/index.test.mjs
@@ -1,48 +1,38 @@
 // index.test.mjs
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
+import { setupTracing, stopTracing, __resetTracingForTesting } from './index.mjs';
 
 describe('setupTracing', () => {
-  let stopTracing;
-
   // Clear environment and reset tracing state before each test
-  beforeEach(async () => {
+  beforeEach(() => {
     delete process.env.SERVICE_NAME;
     delete process.env.ENDPOINT;
     delete process.env.HOSTNAME;
     delete process.env.CONTAINER_NAME;
 
-    // Import and store stopTracing for cleanup
-    const tracing = await import('./index.mjs');
-    stopTracing = tracing.stopTracing;
-
     // Reset singleton for test isolation
-    tracing.__resetTracingForTesting();
+    __resetTracingForTesting();
   });
 
   // Clean up tracing after each test
   afterEach(async () => {
-    if (stopTracing) {
-      await stopTracing();
-    }
+    await stopTracing();
   });
 
-  it('should throw error when serviceName is not provided', async () => {
-    const { setupTracing } = await import('./index.mjs');
+  it('should throw error when serviceName is not provided', () => {
     assert.throws(() => {
       setupTracing({ url: 'http://localhost:4317' });
     }, /serviceName is required/);
   });
 
-  it('should throw error when url is not provided', async () => {
-    const { setupTracing } = await import('./index.mjs');
+  it('should throw error when url is not provided', () => {
     assert.throws(() => {
       setupTracing({ serviceName: 'test-service' });
     }, /url is required/);
   });
 
-  it('should create a tracer with required parameters', async () => {
-    const { setupTracing } = await import('./index.mjs');
+  it('should create a tracer with required parameters', () => {
     const tracer = setupTracing({
       serviceName: 'test-service',
       url: 'http://localhost:4317',
@@ -50,8 +40,7 @@ describe('setupTracing', () => {
     assert.ok(tracer, 'tracer should be defined');
   });
 
-  it('should accept hostname parameter', async () => {
-    const { setupTracing } = await import('./index.mjs');
+  it('should accept hostname parameter', () => {
     const tracer = setupTracing({
       serviceName: 'test-service',
       url: 'http://localhost:4317',
@@ -60,8 +49,7 @@ describe('setupTracing', () => {
     assert.ok(tracer, 'tracer should be defined');
   });
 
-  it('should accept optional instrumentations', async () => {
-    const { setupTracing } = await import('./index.mjs');
+  it('should accept optional instrumentations', () => {
     const tracer = setupTracing({
       serviceName: 'test-service',
       url: 'http://localhost:4317',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,33 +1,33 @@
 {
   "name": "@saidsef/tracing-node",
-  "version": "3.22.6",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@saidsef/tracing-node",
-      "version": "3.22.6",
+      "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "^0.220.0",
-        "@opentelemetry/instrumentation": "^0.220.0",
-        "@opentelemetry/instrumentation-aws-sdk": "^0.75.0",
-        "@opentelemetry/instrumentation-connect": "^0.63.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "^0.221.0",
+        "@opentelemetry/instrumentation": "^0.221.0",
+        "@opentelemetry/instrumentation-aws-sdk": "^0.76.0",
+        "@opentelemetry/instrumentation-connect": "^0.64.0",
         "@opentelemetry/instrumentation-dns": "^0.64.0",
-        "@opentelemetry/instrumentation-express": "^0.67.0",
+        "@opentelemetry/instrumentation-express": "^0.69.0",
         "@opentelemetry/instrumentation-fs": "^0.40.0",
-        "@opentelemetry/instrumentation-http": "^0.220.0",
-        "@opentelemetry/instrumentation-ioredis": "^0.68.0",
-        "@opentelemetry/instrumentation-pino": "^0.66.0",
-        "@opentelemetry/resources": "^2.8.0",
-        "@opentelemetry/sdk-trace-base": "^2.8.0",
-        "@opentelemetry/sdk-trace-node": "^2.8.0",
-        "@opentelemetry/semantic-conventions": "^1.41.1",
+        "@opentelemetry/instrumentation-http": "^0.221.0",
+        "@opentelemetry/instrumentation-ioredis": "^0.69.0",
+        "@opentelemetry/instrumentation-pino": "^0.67.0",
+        "@opentelemetry/resources": "^2.10.0",
+        "@opentelemetry/sdk-trace-base": "^2.10.0",
+        "@opentelemetry/sdk-trace-node": "^2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.43.0",
         "opentelemetry-instrumentation-elasticsearch": "^0.41.0"
       },
       "devDependencies": {
-        "eslint": "^10.5.0"
+        "eslint": "^10.8.0"
       },
       "engines": {
         "node": ">= 20"
@@ -243,9 +243,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
-      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -255,9 +255,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.9.0.tgz",
-      "integrity": "sha512-OQ0vzvbZBiUhjqLnUaoNfYmP8553Crr3aggB4y0ZUi815mZ7idpdJXQmoKdeBKJelYttoBlLSSHubmyw3wvX4w==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.10.0.tgz",
+      "integrity": "sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
-      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -282,16 +282,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.220.0.tgz",
-      "integrity": "sha512-bv1xmNhmNwIM6MdUBw4yYuJeVcEViVLk3uD69vOQMwueHBnfyl/u0HnBlB1FNY/Te0UOzJzvcbyR8wN6b+iGbA==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.221.0.tgz",
+      "integrity": "sha512-zXminlZedtq9LvOW64CnNkOqk15zV75k8JgtdTuWFge6+jk2m4GmAUm6L2eIiG1o2a2bZxXw2PDrszm+bps0IA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.14.3",
-        "@opentelemetry/otlp-exporter-base": "0.220.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.220.0",
-        "@opentelemetry/otlp-transformer": "0.220.0",
-        "@opentelemetry/sdk-trace": "2.9.0"
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -301,12 +300,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
-      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.221.0.tgz",
+      "integrity": "sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.220.0",
+        "@opentelemetry/api-logs": "0.221.0",
         "import-in-the-middle": "^3.0.0",
         "require-in-the-middle": "^8.0.0"
       },
@@ -318,13 +317,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-sdk": {
-      "version": "0.75.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.75.0.tgz",
-      "integrity": "sha512-RLosRcyIojBDzX6uPcooDlpJH5UFzbOZXwLp4NKl2FHy0UgmMfQU+mmul12wEohKTDiGumWouw43yRF69NAfbQ==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.76.0.tgz",
+      "integrity": "sha512-gg2QaDtWeFezRt2mAl9vBQ38y60tzUShKg1KA9uTgsMJimUHaBnB3X8kEH9Of8jKWT4DDoDcSA37gPcoEc0hiA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/instrumentation": "^0.221.0",
         "@opentelemetry/semantic-conventions": "^1.34.0"
       },
       "engines": {
@@ -335,13 +334,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-connect": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.63.0.tgz",
-      "integrity": "sha512-Lg13vVEtZe2yvOyLr61qJHSiD1p0+CTMZhV7mlcRuVABPrfrWuqeEKamsZW0r04DP6LOoVZAvIb3iU7DV4/nEA==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.64.0.tgz",
+      "integrity": "sha512-D1Tpom3BpY8g29FFOEQ2FZioVFjyXwXHsh3BOn2BHcg7Taipg+yc+DPGUwvdR4WZrKnNMAG/+FBXNa0S0KhJYA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/instrumentation": "^0.221.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/connect": "3.4.38"
       },
@@ -367,73 +366,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-dns/node_modules/@opentelemetry/api-logs": {
-      "version": "0.221.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
-      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-dns/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.221.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.221.0.tgz",
-      "integrity": "sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.221.0",
-        "import-in-the-middle": "^3.0.0",
-        "require-in-the-middle": "^8.0.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-express": {
-      "version": "0.67.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.67.0.tgz",
-      "integrity": "sha512-1WTWX2YNZIV+jPmEqdf/Vd1gHMT92TKA/0pf/iIItWhV6+RhzhnUUW4kSWQn8L3qVcgWEzQ860/ZOwaIwayi8A==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.69.0.tgz",
+      "integrity": "sha512-91pHMujQgDyhEQrdg8RriMBrRZ/qPaJ0Y2dopQ6lHjW5YjoeytWi8ruM//T6f5o0D95hnqRlv79Pel1lGPqaYg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.219.0",
+        "@opentelemetry/core": "^2.9.0",
+        "@opentelemetry/instrumentation": "^0.221.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-express/node_modules/@opentelemetry/api-logs": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.219.0.tgz",
-      "integrity": "sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-express/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.219.0.tgz",
-      "integrity": "sha512-X5t7I8GyIO9rmGHwoedZLREpQqrF1WW2nxzNNym6HOKpFiE+rvqV3ngC0xcZVO2YwIGf3KKmRdWrYwdwz3H9RQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.219.0",
-        "import-in-the-middle": "^3.0.0",
-        "require-in-the-middle": "^8.0.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -458,43 +399,14 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-fs/node_modules/@opentelemetry/api-logs": {
-      "version": "0.221.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
-      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-fs/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.221.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.221.0.tgz",
-      "integrity": "sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.221.0",
-        "import-in-the-middle": "^3.0.0",
-        "require-in-the-middle": "^8.0.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.220.0.tgz",
-      "integrity": "sha512-Szt4dO2Boz2CDr38DaSw/lnqwhwKl+IAdgNGEGgSm2Anb+fwPtIAGmIwkhsLLN69QQZQE96JxjMKYY4rlRkYKw==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.221.0.tgz",
+      "integrity": "sha512-oIP91CPIANuYr09tGFElPFKAh6JUar+awJf1kBRYlaeo9b0gDwZHEB2zBfFlvdNFHm0wAVutMZODVi5smKT30g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/instrumentation": "0.220.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/instrumentation": "0.221.0",
         "@opentelemetry/semantic-conventions": "^1.29.0",
         "forwarded-parse": "2.1.2"
       },
@@ -506,12 +418,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-ioredis": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.68.0.tgz",
-      "integrity": "sha512-M2MWPoKiMlNWzmW7+AwEwiFpTJQ7bhKpZuo9L3MS/z/KFm2yXY6B43IprAVyiszLFg8/JsF39t8b8wkGpxip2g==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.69.0.tgz",
+      "integrity": "sha512-I9sZtxXWZ1tRXtRNTEVxpokGtXy6RL1SZhtPVh7zxH78t8ar71V5Dx4bnQiUjKTDzItpC73krD8c0/cEWA9oLg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/instrumentation": "^0.221.0",
         "@opentelemetry/redis-common": "^0.38.3",
         "@opentelemetry/semantic-conventions": "^1.33.0"
       },
@@ -523,14 +435,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pino": {
-      "version": "0.66.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.66.0.tgz",
-      "integrity": "sha512-RMAtAYuyouaMbHkQG8E97nJfwHftxmCbOURdD3n5s2Yd5zctLNudXB5hAfW18lsfUbePwQCND6QUXZixFN92Pw==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.67.0.tgz",
+      "integrity": "sha512-Hb6phi2x1bq23OIiesj4imQvXs9Y5MMLtpgXH9hOuMm9LpBYz2cxPNgpgZ/XATuRclP1eRPoSl399o5XKwfoIA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.220.0",
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/api-logs": "^0.221.0",
+        "@opentelemetry/core": "^2.9.0",
+        "@opentelemetry/instrumentation": "^0.221.0",
         "@opentelemetry/semantic-conventions": "^1.41.1"
       },
       "engines": {
@@ -541,13 +453,13 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.220.0.tgz",
-      "integrity": "sha512-CXYo8UD5Mn9YbgebO2EL4wejtA+gxLmLiu6HCk2KH2BR7XhFN6/6p1UlCb23DYCjeYkndevLHuejCCN1yx4+OQ==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.221.0.tgz",
+      "integrity": "sha512-UFPIq80OH3Ns/oPFHRj14d4DTOxUo+MUFU8hUiCq5jTqFhdeJnfVSANHT+xp92409cA+oxzvlZCe6NM1wvCuBA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/otlp-transformer": "0.220.0"
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/otlp-transformer": "0.221.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -557,15 +469,15 @@
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.220.0.tgz",
-      "integrity": "sha512-/eIkBPMBTIvM3x/0mDX4aJeSkYifYClnBPr68PL1h5LV4VQv4+SV6CGrpiZ4fIWDnobVmhTWCm1J/QRdAWUfvA==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.221.0.tgz",
+      "integrity": "sha512-rQDmNgyiGCTrescjnzH2ntVyUKVIq6I2UjuK8+stT/Xg0ZOT71FVJqwjFdspQl6Yol/Yqsut9bDo+ame8oTmDQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.3",
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/otlp-exporter-base": "0.220.0",
-        "@opentelemetry/otlp-transformer": "0.220.0"
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -575,17 +487,17 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.220.0.tgz",
-      "integrity": "sha512-lXGrv7KXZ0gNH9SVNUaa6vv6phVYGvJxfXAlMbzbakiXru75f5MZl8Z7oqiMMQD77riVHJCFlQvbZs/VVN2/4A==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.221.0.tgz",
+      "integrity": "sha512-lg6lkOU08Az23jVcn/0Els9HP+V8PnR4Km6p0KgpTggS0n/WuhnmY64rSh83Of9iR9nD+dpWr6adlcX8KzAwjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.220.0",
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/sdk-logs": "0.220.0",
-        "@opentelemetry/sdk-metrics": "2.9.0",
-        "@opentelemetry/sdk-trace": "2.9.0"
+        "@opentelemetry/api-logs": "0.221.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-logs": "0.221.0",
+        "@opentelemetry/sdk-metrics": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -604,12 +516,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
-      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/core": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -620,14 +532,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.220.0.tgz",
-      "integrity": "sha512-WywcTkQtv2iNmt+6y5Kcd4rzvx9bLVsBa2Nwcmg01IUaBTkTow3W4d9KE5vNBpEDtb9tp21WcRBY/lANRrApYA==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.221.0.tgz",
+      "integrity": "sha512-FaDcazjyMp7TZZZAsqbo4IkovP0UegoCu0EBkiNt+qCqvUf7FPAsfcrZ3+ZEkKgXZ/jHafop+JoGPDk3A0SmLg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.220.0",
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/api-logs": "0.221.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -638,13 +550,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz",
-      "integrity": "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.10.0.tgz",
+      "integrity": "sha512-t6r1VSvXNtSDnPXU1FbZeetJb7yyovHmgu0wRSoftxtE0g2rSNhQZQUy69sRUCL+iioJpX8SN/S6wq6ZtvLySQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/resources": "2.9.0"
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -654,13 +566,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
-      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -671,14 +583,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
-      "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/sdk-trace": "2.9.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -689,14 +601,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.9.0.tgz",
-      "integrity": "sha512-ec9a7ps37huy5itYk0MalaZdSLlM6AXWp/FhtEjgMpp5leEGojBDvAl/UWttQnkMZOvFHKzRESn8TD3yKTF5nQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.10.0.tgz",
+      "integrity": "sha512-GZK/G6oZyBLGlH1pUgeDch7D91KoHd2uotUGIkWCPi9GI5T9X0p4L7nNAMDR1BQjkRYoDqo+ddfVx9t5Uhys+Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "2.9.0",
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/sdk-trace-base": "2.9.0"
+        "@opentelemetry/context-async-hooks": "2.10.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/sdk-trace-base": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -899,16 +811,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/cjs-module-lexer": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saidsef/tracing-node",
-  "version": "3.22.6",
+  "version": "4.0.0",
   "description": "tracing NodeJS - Wrapper for OpenTelemetry instrumentation packages",
   "main": "libs/index.mjs",
   "scripts": {
@@ -31,30 +31,30 @@
   "homepage": "https://github.com/saidsef/tracing-node#readme",
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "^0.220.0",
-    "@opentelemetry/instrumentation": "^0.220.0",
-    "@opentelemetry/instrumentation-aws-sdk": "^0.75.0",
-    "@opentelemetry/instrumentation-connect": "^0.63.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.221.0",
+    "@opentelemetry/instrumentation": "^0.221.0",
+    "@opentelemetry/instrumentation-aws-sdk": "^0.76.0",
+    "@opentelemetry/instrumentation-connect": "^0.64.0",
     "@opentelemetry/instrumentation-dns": "^0.64.0",
-    "@opentelemetry/instrumentation-express": "^0.67.0",
+    "@opentelemetry/instrumentation-express": "^0.69.0",
     "@opentelemetry/instrumentation-fs": "^0.40.0",
-    "@opentelemetry/instrumentation-http": "^0.220.0",
-    "@opentelemetry/instrumentation-ioredis": "^0.68.0",
-    "@opentelemetry/instrumentation-pino": "^0.66.0",
-    "@opentelemetry/resources": "^2.8.0",
-    "@opentelemetry/sdk-trace-base": "^2.8.0",
-    "@opentelemetry/sdk-trace-node": "^2.8.0",
-    "@opentelemetry/semantic-conventions": "^1.41.1",
+    "@opentelemetry/instrumentation-http": "^0.221.0",
+    "@opentelemetry/instrumentation-ioredis": "^0.69.0",
+    "@opentelemetry/instrumentation-pino": "^0.67.0",
+    "@opentelemetry/resources": "^2.10.0",
+    "@opentelemetry/sdk-trace-base": "^2.10.0",
+    "@opentelemetry/sdk-trace-node": "^2.10.0",
+    "@opentelemetry/semantic-conventions": "^1.43.0",
     "opentelemetry-instrumentation-elasticsearch": "^0.41.0"
   },
   "devDependencies": {
-    "eslint": "^10.5.0"
+    "eslint": "^10.8.0"
   },
   "overrides": {
     "protobufjs": "^7.5.3",
-    "@opentelemetry/core": "^2.8.0"
+    "@opentelemetry/core": "^2.10.0"
   },
   "allowScripts": {
-    "protobufjs@7.6.4": true
+    "protobufjs@7.6.5": true
   }
 }


### PR DESCRIPTION
Closes #541

Updates all 11 outdated `@opentelemetry/*` packages and moves emitted spans onto the stable semantic conventions. Releases as 4.0.0.

## Breaking change

Spans now carry stable semantic convention attributes. Upstream deleted the legacy attributes along with the `OTEL_SEMCONV_STABILITY_OPT_IN` escape hatch (opentelemetry-js-contrib#3585, opentelemetry-js#6819), so there is no way to keep the old names.

Worth being explicit about why this is not optional: 0.220.0 defaulted to the legacy set when that env var was unset, which is our case, so every consumer's spans change whether or not they do anything.

```
http.method       -> http.request.method
http.status_code  -> http.response.status_code
http.url          -> url.full
net.peer.name     -> server.address
db.system         -> db.system.name
db.statement      -> db.query.text
```

The full table, including the metrics unit change, is in the README. The `setupTracing` / `stopTracing` API is unchanged, so consumers need no code changes. Only dashboards, alerts and processors keyed on the old names need updating. `peer.service` is untouched, so service graphs keep working.

## Dependencies

| Package | From | To |
|---|---|---|
| exporter-trace-otlp-grpc, instrumentation, instrumentation-http | 0.220.0 | 0.221.0 |
| instrumentation-express | 0.67.0 | 0.69.0 |
| instrumentation-aws-sdk | 0.75.0 | 0.76.0 |
| instrumentation-ioredis | 0.68.0 | 0.69.0 |
| instrumentation-connect | 0.63.0 | 0.64.0 |
| instrumentation-pino | 0.66.0 | 0.67.0 |
| resources, sdk-trace-base, sdk-trace-node, core override | 2.8.0 | 2.10.0 |
| semantic-conventions | 1.41.1 | 1.43.0 |
| eslint (dev) | 10.5.0 | 10.8.0 |

Also clears a high severity `brace-expansion` advisory (dev-only, via `eslint -> minimatch`) and refreshes the stale `protobufjs` allowScripts pin that was warning on every install. `npm audit` is now clean.

## Cleanup

`libs/` loses 48 lines that the new versions made dead or duplicated. Each of these was verified by running the real instrumentation, not by reading changelogs:

- `serverName` is deprecated and unreferenced in the 0.221.0 runtime.
- The case-insensitive header fallbacks could never match, because Node lowercases every `IncomingMessage` header key.
- `requestHook` returned early for every outgoing request, since `ClientRequest` exposes `getHeaders()` rather than `.headers`. Client spans now get the enrichment server spans already had.
- `http.user_agent` duplicated `user_agent.original`.
- Peer service detection tested for ports that `.host` never carries, and matched the request path, so an inbound request to `/redis/status` was tagged `peer.service: redis`. It now matches the outbound host only.
- The redis statement serializer decoded entire Buffers before truncating to 100 chars. Slicing first measures 36us to 0.30us per call on a 1MB Buffer, with byte-identical output across 8132 fuzz cases.
- The JSDoc block sat above the `tracerProvider` declaration rather than `setupTracing`, and documented the wrong default for `hostname`.
- Library diagnostics go through the OTel diag logger instead of `console`, so a consumer-installed `DiagLogger` actually receives them.

## Verification

- `npm test` 5/5, `eslint` clean, `npm audit` 0 vulnerabilities.
- An end-to-end check drives a live HTTP server through the library and asserts on the captured span attributes: confirms client spans are now enriched, `http.user_agent` is gone, `user_agent.original` is still present, and `/redis/status` no longer produces a false `peer.service`.

## Two things deliberately left alone

- `db.redis.key` is still untruncated. Routing it through the new helper would start truncating keys over 100 chars (hashed keys, `EVAL` scripts), which is a telemetry change rather than a performance fix.
- On client spans, `responseHook` overwrites `http.request_id` with the response's `x-request-id`. Pre-existing and unchanged here, but the attribute is arguably mislabelled. Happy to fix separately if you want it.
