### PR TITLE
feat(instrumentation): trace outgoing fetch calls via undici

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Effortlessly supercharge your applications with world-class distributed tracing!
 | Feature | Description |
 |---------|-------------|
 | HTTP/HTTPS instrumentation | Automatic service detection |
+| fetch/undici instrumentation | Outgoing `globalThis.fetch` calls |
 | Express.js support | Framework instrumentation |
 | Elasticsearch client | Database instrumentation |
 | IORedis client | Cache instrumentation |

--- a/libs/index.mjs
+++ b/libs/index.mjs
@@ -25,6 +25,7 @@ import {ExpressInstrumentation} from '@opentelemetry/instrumentation-express';
 import {NodeTracerProvider} from '@opentelemetry/sdk-trace-node';
 import {OTLPTraceExporter} from '@opentelemetry/exporter-trace-otlp-grpc';
 import {PinoInstrumentation} from '@opentelemetry/instrumentation-pino';
+import {UndiciInstrumentation} from '@opentelemetry/instrumentation-undici';
 import {IORedisInstrumentation} from '@opentelemetry/instrumentation-ioredis';
 import {registerInstrumentations} from '@opentelemetry/instrumentation';
 import {FsInstrumentation} from '@opentelemetry/instrumentation-fs';
@@ -48,6 +49,21 @@ const setIntAttribute = (span, name, value) => {
 const truncateArg = (value, limit) => {
   const str = Buffer.isBuffer(value) ? value.subarray(0, limit * 4 + 8).toString() : String(value);
   return str.length > limit ? `${str.substring(0, limit)}...` : str;
+};
+
+// Tempo names a service-graph node from peer.service, which no instrumentation
+// emits, so both the http and undici hooks below derive it from the remote host.
+const PEER_SERVICES = ['elasticsearch', 'redis'];
+
+const setPeerService = (span, host) => {
+  if (!host) return;
+  for (const service of PEER_SERVICES) {
+    if (host.includes(service)) {
+      span.setAttribute('peer.service', service);
+      span.setAttribute('db.system.name', service);
+      return;
+    }
+  }
 };
 
 let tracerProvider = null; // Declare provider in module scope for access in stopTracing
@@ -134,18 +150,7 @@ export function setupTracing(options = {}) {
 
   // Only an outgoing ClientRequest carries .host, so bailing without it keeps
   // server spans out: peer.service must name the remote service being called.
-  const applyCustomAttributesOnSpan = (span, request) => {
-    const host = request?.host;
-    if (!host) return;
-
-    for (const service of ['elasticsearch', 'redis']) {
-      if (host.includes(service)) {
-        span.setAttribute('peer.service', service);
-        span.setAttribute('db.system.name', service);
-        return;
-      }
-    }
-  };
+  const applyCustomAttributesOnSpan = (span, request) => setPeerService(span, request?.host);
 
   const instrumentations = [
     new HttpInstrumentation({
@@ -177,6 +182,14 @@ export function setupTracing(options = {}) {
         setIntAttribute(span, 'http.response.content_length', headers['content-length']);
         if (requestId) span.setAttribute('http.request_id', requestId);
       },
+    }),
+    // globalThis.fetch runs on undici, which never touches the http/https
+    // modules HttpInstrumentation patches. Without this, fetch calls produce no
+    // client span and inject no traceparent, so the callee starts a new trace
+    // and the two services can never be paired into a service-graph edge.
+    new UndiciInstrumentation({
+      // UndiciRequest exposes origin, not the .host the http hook reads.
+      requestHook: (span, request) => setPeerService(span, request?.origin),
     }),
     new ExpressInstrumentation({
       requestHook: (span, info) => {

--- a/libs/index.test.mjs
+++ b/libs/index.test.mjs
@@ -49,6 +49,20 @@ describe('setupTracing', () => {
     assert.ok(tracer, 'tracer should be defined');
   });
 
+  // globalThis.fetch runs on undici, so it is invisible to HttpInstrumentation.
+  // Registering it must not disturb setup, and the patch has to land on the
+  // global fetch itself - otherwise outgoing calls carry no traceparent.
+  it('should instrument global fetch', () => {
+    const before = globalThis.fetch;
+    const tracer = setupTracing({
+      serviceName: 'test-service',
+      url: 'http://localhost:4317',
+    });
+    assert.ok(tracer, 'tracer should be defined');
+    assert.strictEqual(typeof globalThis.fetch, 'function', 'global fetch should still be callable');
+    assert.ok(before, 'global fetch should exist on a supported runtime');
+  });
+
   it('should accept optional instrumentations', () => {
     const tracer = setupTracing({
       serviceName: 'test-service',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@saidsef/tracing-node",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@saidsef/tracing-node",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -20,6 +20,7 @@
         "@opentelemetry/instrumentation-http": "^0.221.0",
         "@opentelemetry/instrumentation-ioredis": "^0.69.0",
         "@opentelemetry/instrumentation-pino": "^0.67.0",
+        "@opentelemetry/instrumentation-undici": "^0.31.0",
         "@opentelemetry/resources": "^2.10.0",
         "@opentelemetry/sdk-trace-base": "^2.10.0",
         "@opentelemetry/sdk-trace-node": "^2.10.0",
@@ -30,7 +31,7 @@
         "eslint": "^10.8.0"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 20.6.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -450,6 +451,23 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-undici": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.31.0.tgz",
+      "integrity": "sha512-qunCfgSFV+bjRdAYkWIjVX38jIN/Xj80CiERXXdzYAmdigCFvJPB3AY3j43bjJlkhgbJJSCGdbvQUSut8QIiyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.9.0",
+        "@opentelemetry/instrumentation": "^0.221.0",
+        "@opentelemetry/semantic-conventions": "^1.24.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saidsef/tracing-node",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "tracing NodeJS - Wrapper for OpenTelemetry instrumentation packages",
   "main": "libs/index.mjs",
   "scripts": {
@@ -23,7 +23,7 @@
   "author": "Said Sef <saidsef@gmail.com>",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">= 20"
+    "node": ">= 20.6.0"
   },
   "bugs": {
     "url": "https://github.com/saidsef/tracing-node/issues"
@@ -41,6 +41,7 @@
     "@opentelemetry/instrumentation-http": "^0.221.0",
     "@opentelemetry/instrumentation-ioredis": "^0.69.0",
     "@opentelemetry/instrumentation-pino": "^0.67.0",
+    "@opentelemetry/instrumentation-undici": "^0.31.0",
     "@opentelemetry/resources": "^2.10.0",
     "@opentelemetry/sdk-trace-base": "^2.10.0",
     "@opentelemetry/sdk-trace-node": "^2.10.0",


### PR DESCRIPTION
Fixes #545.

`globalThis.fetch` runs on undici, which never touches the `http` or `https` core modules that `HttpInstrumentation` patches. Outgoing fetch calls produced no client span, and no `traceparent` header was injected, so the callee began a fresh trace and the two services could never be paired into a service graph edge.

Registering `UndiciInstrumentation` in `setupTracing` closes both gaps at once, since the same instrumentation that creates the span is what injects the header. There is no way to get one without the other, which is why adding the missing span was never the whole of the problem.

The `peer.service` lookup is now shared between the two hooks. `UndiciRequest` exposes `origin` where `ClientRequest` exposes `host`, but what happens with that value is identical, so the loop that matched a hostname against the known peer names moved out of `setupTracing` into a module-level `setPeerService` helper that both hooks call. A fetch to Elasticsearch or Redis now names its remote exactly as the equivalent `http` call does, which is what keeps the service graph from splitting one dependency into two nodes.

The new dependency declares `>=20.6.0`, so the package `engines` floor moves from `>= 20` to match rather than letting npm resolve an install that cannot run. Version goes to 4.1.0 - additive behaviour, no API change.

## Verification

`eslint` is clean and the test suite passes, 6 of 6. A new test asserts that `setupTracing` still returns a tracer with undici registered and that `globalThis.fetch` is still a callable function afterwards, since an instrumentation that replaced global fetch with something non-callable would break every consumer of the package.

That test does not make a real network call, so span emission and header injection on the wire are covered by the upstream instrumentation rather than here. The six `duplicate registration of API` lines printed during the run come from repeated `tracerProvider.register()` calls across tests and appear identically on `main`, unchanged by this branch.