### PR TITLE
docs(readme): explain where traces go, move the upgrade guide out, fix the fork link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,32 +49,9 @@ The W3C Trace Context propagation this library registers is what lets Tempo pair
 npm install @saidsef/tracing-node --save
 ```
 
-## Upgrading to 4.0.0
+## Upgrading
 
-**Breaking change: spans now carry the stable OpenTelemetry semantic conventions.**
-
-The upstream instrumentations ([open-telemetry/opentelemetry-js-contrib#3585](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3585)) dropped the legacy attributes and removed the `OTEL_SEMCONV_STABILITY_OPT_IN` escape hatch, so there is no way to keep the old names. The public API of `setupTracing` / `stopTracing` is unchanged - no code changes are required - but any dashboard, alert or processor keyed on the old attribute names must be updated.
-
-| Removed | Replacement | Affected spans |
-|---------|-------------|----------------|
-| `http.method` | `http.request.method` | HTTP |
-| `http.status_code` | `http.response.status_code` | HTTP, AWS SDK |
-| `http.url` | `url.full` | HTTP |
-| `http.target` | `url.path` + `url.query` | HTTP |
-| `http.scheme` | `url.scheme` | HTTP |
-| `http.user_agent` | `user_agent.original` | HTTP |
-| `http.client_ip` | `client.address` | HTTP |
-| `http.flavor` | `network.protocol.version` | HTTP |
-| `net.peer.name` | `server.address` | HTTP, IORedis |
-| `net.peer.port` | `server.port` | HTTP, IORedis |
-| `db.system` | `db.system.name` | IORedis, DynamoDB |
-| `db.statement` | `db.query.text` | IORedis, DynamoDB |
-| `db.operation` | `db.operation.name` | IORedis, DynamoDB |
-| `db.connection_string` | none | IORedis |
-
-Server-side HTTP metrics also move from `http.server.duration` (milliseconds) to `http.server.request.duration` (seconds), and the client equivalents likewise.
-
-`peer.service` is unchanged, so Tempo/Grafana service graphs keep working as before. IORedis spans also gain `db.operation.name`, which distinguishes `MULTI`/`PIPELINE` commands.
+Breaking changes and the attribute renames they bring are recorded in the [release notes](https://github.com/saidsef/tracing-node/releases) for the version concerned.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ Effortlessly supercharge your applications with world-class distributed tracing!
 - ...
 - Profit?
 
+## Where the traces go
+
+`setupTracing` exports OTLP over gRPC, so any OpenTelemetry-compatible collector or backend will take it - point `url` at yours.
+
+If you do not have one yet, [grafana-loki-on-k8s](https://github.com/saidsef/grafana-loki-on-k8s) is a companion project that deploys the full LGTM+ stack - Grafana, Prometheus, Mimir, Loki, Tempo, Pyroscope, Alloy and Beyla - to Kubernetes with `kubectl apply -k ./deployment`, broken into small composable manifests rather than a single opaque chart. Send traces to its Alloy OTLP receiver and they land in Tempo, with the metrics-generator turning them into RED and service-graph metrics in Mimir:
+
+```javascript
+setupTracing({serviceName: 'my-service', url: 'http://alloy:4317'});
+```
+
+The W3C Trace Context propagation this library registers is what lets Tempo pair a caller's client span with the callee's server span, which is what a service graph is built from.
+
 ## Instalation
 
 ```
@@ -93,7 +105,7 @@ setupTracing({hostname: 'hostname', serviceName: 'service_name', url: 'endpoint'
 
 ## Source
 
-Our latest and greatest source of `tracing-node` can be found on [GitHub](https://github.com/saidsef/tracing-nodec/fork). Fork us!
+Our latest and greatest source of `tracing-node` can be found on [GitHub](https://github.com/saidsef/tracing-node/fork). Fork us!
 
 ## Contributing
 


### PR DESCRIPTION
Fixes #547.

Three README changes, all aimed at what a reader meets on the way to their first working trace.

Adds a "Where the traces go" section between Prerequisites and Installation, so it sits where the question arises rather than after the parameter table that raises it. It leads with the general answer - the exporter speaks OTLP over gRPC, so any compatible collector or backend will take it, point `url` at yours - because the library is not tied to one stack and should not read as though it is. Only then does it offer a concrete option for readers who have not chosen a backend, naming what sending traces there gets them rather than just linking: a tracing backend, plus RED and service-graph metrics derived from the same spans.

The closing paragraph records why the propagation this library registers matters, which the Features table asserts without explaining. A service graph exists only because a caller's client span and the callee's server span share a trace, and that only happens when trace context crosses the process boundary. It is a property of the SDK setup rather than of whatever backend receives the spans, so it belongs in this README.

The "Upgrading to 4.0.0" section moves to the [v4.0.0 release notes](https://github.com/saidsef/tracing-node/releases/tag/v4.0.0), appended below the generated changelog rather than replacing it. A version-specific rename table sat permanently between Installation and Usage, pushing aside what a reader came for, and that cost only compounds - each future major version either appends another section or leaves a stale one in place. Release notes are already keyed to a version, and a reader reaches them by way of the version they are upgrading from. What remains in the README is a short pointer that stays correct without editing whenever a major version ships.

Also fixes the Source link, which pointed at a repository name with a stray character and returned a 404.

## Verification

`npm test` passes - 6 tests, 0 failures - and `npm run lint` is clean. Neither exercises documentation, so they only confirm nothing else was disturbed.

Every link in the README was followed: the previously broken fork link, the newly added references, and the releases page all resolve. The release notes were read back after editing to confirm the full attribute table survived the move intact alongside the existing changelog.

The example endpoint matches the OTLP gRPC receiver exposed by the project it names, and the described behaviour - propagation yielding a paired service-to-service edge rather than an inferred peer - was confirmed end to end against Tempo 3.0.3, with two services calling each other through this library and the resulting edge carrying no virtual-node marker.

The version stays at 4.1.0. This is a documentation-only change and does not warrant minting a release.
